### PR TITLE
Record max call elapsed times for single methods

### DIFF
--- a/src/main/java/com/google/idea/perf/CallTree.kt
+++ b/src/main/java/com/google/idea/perf/CallTree.kt
@@ -21,6 +21,7 @@ interface CallTree {
     val tracepoint: Tracepoint
     val callCount: Long
     val wallTime: Long
+    val maxCallTime: Long
     val children: Map<Tracepoint, CallTree>
 }
 
@@ -30,6 +31,7 @@ class MutableCallTree(
 ) : CallTree {
     override var callCount: Long = 0
     override var wallTime: Long = 0
+    override var maxCallTime: Long = 0
     override val children: MutableMap<Tracepoint, MutableCallTree> = LinkedHashMap()
 
     /** Accumulates the data from another call tree into this one. */
@@ -40,6 +42,7 @@ class MutableCallTree(
 
         callCount += other.callCount
         wallTime += other.wallTime
+        maxCallTime = maxCallTime.coerceAtLeast(other.maxCallTime)
 
         for ((childTracepoint, otherChild) in other.children) {
             val child = children.getOrPut(childTracepoint) { MutableCallTree(childTracepoint) }
@@ -50,6 +53,7 @@ class MutableCallTree(
     fun clear() {
         callCount = 0
         wallTime = 0
+        maxCallTime = 0
         children.values.forEach(MutableCallTree::clear)
     }
 }
@@ -58,7 +62,8 @@ class MutableCallTree(
 class TracepointStats(
     val tracepoint: Tracepoint,
     var callCount: Long = 0,
-    var wallTime: Long = 0
+    var wallTime: Long = 0,
+    var maxCallTime: Long = 0
 )
 
 object TreeAlgorithms {
@@ -76,6 +81,7 @@ object TreeAlgorithms {
             stats.callCount += node.callCount
             if (nonRecursive) {
                 stats.wallTime += node.wallTime
+                stats.maxCallTime = stats.maxCallTime.coerceAtLeast(node.maxCallTime)
                 ancestors.add(node.tracepoint)
             }
             for (child in node.children.values) {

--- a/src/main/java/com/google/idea/perf/CallTree.kt
+++ b/src/main/java/com/google/idea/perf/CallTree.kt
@@ -21,7 +21,7 @@ interface CallTree {
     val tracepoint: Tracepoint
     val callCount: Long
     val wallTime: Long
-    val maxCallTime: Long
+    val maxWallTime: Long
     val children: Map<Tracepoint, CallTree>
 }
 
@@ -31,7 +31,7 @@ class MutableCallTree(
 ) : CallTree {
     override var callCount: Long = 0
     override var wallTime: Long = 0
-    override var maxCallTime: Long = 0
+    override var maxWallTime: Long = 0
     override val children: MutableMap<Tracepoint, MutableCallTree> = LinkedHashMap()
 
     /** Accumulates the data from another call tree into this one. */
@@ -42,7 +42,7 @@ class MutableCallTree(
 
         callCount += other.callCount
         wallTime += other.wallTime
-        maxCallTime = maxCallTime.coerceAtLeast(other.maxCallTime)
+        maxWallTime = maxWallTime.coerceAtLeast(other.maxWallTime)
 
         for ((childTracepoint, otherChild) in other.children) {
             val child = children.getOrPut(childTracepoint) { MutableCallTree(childTracepoint) }
@@ -53,7 +53,7 @@ class MutableCallTree(
     fun clear() {
         callCount = 0
         wallTime = 0
-        maxCallTime = 0
+        maxWallTime = 0
         children.values.forEach(MutableCallTree::clear)
     }
 }
@@ -63,7 +63,7 @@ class TracepointStats(
     val tracepoint: Tracepoint,
     var callCount: Long = 0,
     var wallTime: Long = 0,
-    var maxCallTime: Long = 0
+    var maxWallTime: Long = 0
 )
 
 object TreeAlgorithms {
@@ -81,7 +81,7 @@ object TreeAlgorithms {
             stats.callCount += node.callCount
             if (nonRecursive) {
                 stats.wallTime += node.wallTime
-                stats.maxCallTime = stats.maxCallTime.coerceAtLeast(node.maxCallTime)
+                stats.maxWallTime = stats.maxWallTime.coerceAtLeast(node.maxWallTime)
                 ancestors.add(node.tracepoint)
             }
             for (child in node.children.values) {

--- a/src/main/java/com/google/idea/perf/CallTreeBuilder.kt
+++ b/src/main/java/com/google/idea/perf/CallTreeBuilder.kt
@@ -34,7 +34,9 @@ class CallTreeBuilder(
     private var currentNode = root
 
     init {
-        root.continuedWallTime = clock.sample()
+        val now = clock.sample()
+        root.startWallTime = now
+        root.continuedWallTime = now
     }
 
     interface Clock {

--- a/src/main/java/com/google/idea/perf/CallTreeBuilder.kt
+++ b/src/main/java/com/google/idea/perf/CallTreeBuilder.kt
@@ -53,7 +53,7 @@ class CallTreeBuilder(
     ) : CallTree {
         override var callCount: Long = 0
         override var wallTime: Long = 0
-        override var maxCallTime: Long = 0
+        override var maxWallTime: Long = 0
         override val children: MutableMap<Tracepoint, Tree> = LinkedHashMap()
 
         var startWallTime: Long = 0
@@ -96,7 +96,7 @@ class CallTreeBuilder(
 
         val now = clock.sample()
         child.wallTime += now - child.continuedWallTime
-        child.maxCallTime = child.maxCallTime.coerceAtLeast(now - child.startWallTime)
+        child.maxWallTime = child.maxWallTime.coerceAtLeast(now - child.startWallTime)
 
         currentNode = parent
     }
@@ -109,7 +109,7 @@ class CallTreeBuilder(
             val elapsedTime = now - node.continuedWallTime
             node.wallTime += elapsedTime
             node.continuedWallTime = now
-            node.maxCallTime = node.maxCallTime.coerceAtLeast(now - node.startWallTime)
+            node.maxWallTime = node.maxWallTime.coerceAtLeast(now - node.startWallTime)
         }
 
         // Reset to a new tree and copy over the current stack.

--- a/src/main/java/com/google/idea/perf/TracepointTable.kt
+++ b/src/main/java/com/google/idea/perf/TracepointTable.kt
@@ -35,7 +35,7 @@ import javax.swing.table.TableRowSorter
 private const val TRACEPOINT = 0
 private const val CALLS = 1
 private const val WALL_TIME = 2
-private const val MAX_CALL_TIME = 3
+private const val MAX_WALL_TIME = 3
 private const val COL_COUNT = 4
 
 /** The table model for [TracepointTable]. */
@@ -53,13 +53,13 @@ class TracepointTableModel : AbstractTableModel() {
         TRACEPOINT -> "tracepoint"
         CALLS -> "calls"
         WALL_TIME -> "wall time"
-        MAX_CALL_TIME -> "max call time"
+        MAX_WALL_TIME -> "max wall time"
         else -> error(col)
     }
 
     override fun getColumnClass(col: Int): Class<*> = when (col) {
         TRACEPOINT -> java.lang.String::class.java
-        CALLS, WALL_TIME, MAX_CALL_TIME -> java.lang.Long::class.java
+        CALLS, WALL_TIME, MAX_WALL_TIME -> java.lang.Long::class.java
         else -> error(col)
     }
 
@@ -71,7 +71,7 @@ class TracepointTableModel : AbstractTableModel() {
             TRACEPOINT -> stats.tracepoint.displayName
             CALLS -> stats.callCount
             WALL_TIME -> stats.wallTime
-            MAX_CALL_TIME -> stats.maxCallTime
+            MAX_WALL_TIME -> stats.maxWallTime
             else -> error(col)
         }
     }
@@ -96,13 +96,13 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
             tableColumn.minWidth = 100
             tableColumn.preferredWidth = when (col) {
                 TRACEPOINT -> Integer.MAX_VALUE
-                CALLS, WALL_TIME, MAX_CALL_TIME -> 100
+                CALLS, WALL_TIME, MAX_WALL_TIME -> 100
                 else -> tableColumn.preferredWidth
             }
 
             // Locale-aware and unit-aware rendering for numbers.
             when (col) {
-                CALLS, WALL_TIME, MAX_CALL_TIME -> {
+                CALLS, WALL_TIME, MAX_WALL_TIME -> {
                     tableColumn.cellRenderer = object : DefaultTableCellRenderer() {
                         init {
                             horizontalAlignment = SwingConstants.RIGHT
@@ -114,7 +114,7 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
                             }
                             val formatted = when (col) {
                                 WALL_TIME -> formatNsInMs(value)
-                                MAX_CALL_TIME -> formatNsInMs(value)
+                                MAX_WALL_TIME -> formatNsInMs(value)
                                 else -> formatNum(value)
                             }
                             super.setValue(formatted)

--- a/src/main/java/com/google/idea/perf/TracepointTable.kt
+++ b/src/main/java/com/google/idea/perf/TracepointTable.kt
@@ -35,7 +35,8 @@ import javax.swing.table.TableRowSorter
 private const val TRACEPOINT = 0
 private const val CALLS = 1
 private const val WALL_TIME = 2
-private const val COL_COUNT = 3
+private const val MAX_CALL_TIME = 3
+private const val COL_COUNT = 4
 
 /** The table model for [TracepointTable]. */
 class TracepointTableModel : AbstractTableModel() {
@@ -52,12 +53,13 @@ class TracepointTableModel : AbstractTableModel() {
         TRACEPOINT -> "tracepoint"
         CALLS -> "calls"
         WALL_TIME -> "wall time"
+        MAX_CALL_TIME -> "max call time"
         else -> error(col)
     }
 
     override fun getColumnClass(col: Int): Class<*> = when (col) {
         TRACEPOINT -> java.lang.String::class.java
-        CALLS, WALL_TIME -> java.lang.Long::class.java
+        CALLS, WALL_TIME, MAX_CALL_TIME -> java.lang.Long::class.java
         else -> error(col)
     }
 
@@ -69,6 +71,7 @@ class TracepointTableModel : AbstractTableModel() {
             TRACEPOINT -> stats.tracepoint.displayName
             CALLS -> stats.callCount
             WALL_TIME -> stats.wallTime
+            MAX_CALL_TIME -> stats.maxCallTime
             else -> error(col)
         }
     }
@@ -93,13 +96,13 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
             tableColumn.minWidth = 100
             tableColumn.preferredWidth = when (col) {
                 TRACEPOINT -> Integer.MAX_VALUE
-                CALLS, WALL_TIME -> 100
+                CALLS, WALL_TIME, MAX_CALL_TIME -> 100
                 else -> tableColumn.preferredWidth
             }
 
             // Locale-aware and unit-aware rendering for numbers.
             when (col) {
-                CALLS, WALL_TIME -> {
+                CALLS, WALL_TIME, MAX_CALL_TIME -> {
                     tableColumn.cellRenderer = object : DefaultTableCellRenderer() {
                         init {
                             horizontalAlignment = SwingConstants.RIGHT
@@ -111,6 +114,7 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
                             }
                             val formatted = when (col) {
                                 WALL_TIME -> formatNsInMs(value)
+                                MAX_CALL_TIME -> formatNsInMs(value)
                                 else -> formatNum(value)
                             }
                             super.setValue(formatted)

--- a/src/test/java/com/google/idea/perf/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/CallTreeTest.kt
@@ -25,7 +25,7 @@ class CallTreeTest {
         override val tracepoint: Tracepoint,
         override val callCount: Long,
         override val wallTime: Long,
-        override val maxCallTime: Long,
+        override val maxWallTime: Long,
         childrenList: List<Tree> = emptyList()
     ) : CallTree {
         override val children = childrenList.associateBy { it.tracepoint }
@@ -79,7 +79,7 @@ class CallTreeTest {
             .sortedBy { it.tracepoint.displayName }
             .joinToString(separator = "\n") { stats ->
                 with(stats) {
-                    "$tracepoint: $callCount calls, $wallTime ns, $maxCallTime ns"
+                    "$tracepoint: $callCount calls, $wallTime ns, $maxWallTime ns"
                 }
             }
 
@@ -153,7 +153,7 @@ class CallTreeTest {
 
         fun StringBuilder.printTree(node: CallTree, indent: String) {
             with(node) {
-                appendln("$indent$tracepoint: $callCount calls, $wallTime ns, $maxCallTime ns")
+                appendln("$indent$tracepoint: $callCount calls, $wallTime ns, $maxWallTime ns")
             }
             for (child in node.children.values) {
                 printTree(child, "$indent  ")

--- a/src/test/java/com/google/idea/perf/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/CallTreeTest.kt
@@ -187,7 +187,7 @@ class CallTreeTest {
         builder.push(simple3); clock.time++
         buildAndCheckTree(
             """
-            [root]: 0 calls, 3 ns, 3 ns
+            [root]: 0 calls, 3 ns, 18 ns
               simple1: 1 calls, 3 ns, 3 ns
                 simple2: 1 calls, 2 ns, 2 ns
                   simple3: 1 calls, 1 ns, 1 ns
@@ -197,10 +197,22 @@ class CallTreeTest {
         clock.time += 10
         buildAndCheckTree(
             """
-            [root]: 0 calls, 10 ns, 10 ns
-              simple1: 0 calls, 10 ns, 10 ns
-                simple2: 0 calls, 10 ns, 10 ns
-                  simple3: 0 calls, 10 ns, 10 ns
+            [root]: 0 calls, 10 ns, 28 ns
+              simple1: 0 calls, 10 ns, 13 ns
+                simple2: 0 calls, 10 ns, 12 ns
+                  simple3: 0 calls, 10 ns, 11 ns
+            """.trimIndent()
+        )
+
+        builder.pop(simple3); clock.time++
+        builder.pop(simple2); clock.time++
+        builder.pop(simple1)
+        buildAndCheckTree(
+            """
+            [root]: 0 calls, 2 ns, 30 ns
+              simple1: 0 calls, 2 ns, 15 ns
+                simple2: 0 calls, 1 ns, 13 ns
+                  simple3: 0 calls, 0 ns, 11 ns
             """.trimIndent()
         )
     }

--- a/src/test/java/com/google/idea/perf/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/CallTreeTest.kt
@@ -25,9 +25,15 @@ class CallTreeTest {
         override val tracepoint: Tracepoint,
         override val callCount: Long,
         override val wallTime: Long,
+        override val maxCallTime: Long,
         childrenList: List<Tree> = emptyList()
     ) : CallTree {
         override val children = childrenList.associateBy { it.tracepoint }
+    }
+
+    init {
+        // Enforce LF line endings for developers on Windows.
+        System.setProperty("line.separator", "\n");
     }
 
     @Test
@@ -41,29 +47,29 @@ class CallTreeTest {
         val mutualRecursion1 = Tracepoint("mutualRecursion1")
         val mutualRecursion2 = Tracepoint("mutualRecursion2")
 
-        val tree = Tree(Tracepoint.ROOT, 0, 0, listOf(
+        val tree = Tree(Tracepoint.ROOT, 0, 0, 0, listOf(
             // Simple.
-            Tree(simple1, 16, 1600, listOf(
-                Tree(simple2, 8, 800, listOf(
-                    Tree(simple3, 2, 200)
+            Tree(simple1, 16, 1600, 100, listOf(
+                Tree(simple2, 8, 800, 100, listOf(
+                    Tree(simple3, 2, 200, 150)
                 )),
-                Tree(simple3, 4, 400, listOf(
-                    Tree(simple2, 1, 100)
+                Tree(simple3, 4, 400, 100, listOf(
+                    Tree(simple2, 1, 100, 100)
                 ))
             )),
 
             // Self recursion.
-            Tree(selfRecursion, 4, 400, listOf(
-                Tree(selfRecursion, 2, 200, listOf(
-                    Tree(selfRecursion, 1, 100)
+            Tree(selfRecursion, 4, 400, 200, listOf(
+                Tree(selfRecursion, 2, 200, 100, listOf(
+                    Tree(selfRecursion, 1, 100, 100)
                 ))
             )),
 
             // Mutual recursion.
-            Tree(mutualRecursion1, 1, 800, listOf(
-                Tree(mutualRecursion2, 2, 400, listOf(
-                    Tree(mutualRecursion1, 4, 200, listOf(
-                        Tree(mutualRecursion2, 8, 100)
+            Tree(mutualRecursion1, 1, 800, 800, listOf(
+                Tree(mutualRecursion2, 2, 400, 200, listOf(
+                    Tree(mutualRecursion1, 4, 200, 50, listOf(
+                        Tree(mutualRecursion2, 8, 100, 13)
                     ))
                 ))
             ))
@@ -73,18 +79,18 @@ class CallTreeTest {
             .sortedBy { it.tracepoint.displayName }
             .joinToString(separator = "\n") { stats ->
                 with(stats) {
-                    "$tracepoint: $callCount calls, $wallTime ns"
+                    "$tracepoint: $callCount calls, $wallTime ns, $maxCallTime ns"
                 }
             }
 
         val expected = """
-            [root]: 0 calls, 0 ns
-            mutualRecursion1: 5 calls, 800 ns
-            mutualRecursion2: 10 calls, 400 ns
-            selfRecursion: 7 calls, 400 ns
-            simple1: 16 calls, 1600 ns
-            simple2: 9 calls, 900 ns
-            simple3: 6 calls, 600 ns
+            [root]: 0 calls, 0 ns, 0 ns
+            mutualRecursion1: 5 calls, 800 ns, 800 ns
+            mutualRecursion2: 10 calls, 400 ns, 200 ns
+            selfRecursion: 7 calls, 400 ns, 200 ns
+            simple1: 16 calls, 1600 ns, 100 ns
+            simple2: 9 calls, 900 ns, 100 ns
+            simple3: 6 calls, 600 ns, 150 ns
         """.trimIndent()
 
         assertEquals(expected, allStats)
@@ -117,6 +123,16 @@ class CallTreeTest {
         builder.pop(simple2); clock.time++
         builder.pop(simple1)
 
+        // Simple (longer).
+        builder.push(simple1)
+        builder.push(simple2); clock.time++
+        builder.push(simple3); clock.time++
+        builder.pop(simple3); clock.time++
+        builder.pop(simple2)
+        builder.push(simple2); clock.time++
+        builder.pop(simple2)
+        builder.pop(simple1)
+
         // Self recursion.
         builder.push(selfRecursion); clock.time++
         builder.push(selfRecursion); clock.time++
@@ -132,12 +148,12 @@ class CallTreeTest {
         builder.push(mutualRecursion2); clock.time++
         builder.pop(mutualRecursion2)
         builder.pop(mutualRecursion1)
-        builder.pop(mutualRecursion2);
+        builder.pop(mutualRecursion2)
         builder.pop(mutualRecursion1)
 
         fun StringBuilder.printTree(node: CallTree, indent: String) {
             with(node) {
-                appendln("$indent$tracepoint: $callCount calls, $wallTime ns")
+                appendln("$indent$tracepoint: $callCount calls, $wallTime ns, $maxCallTime ns")
             }
             for (child in node.children.values) {
                 printTree(child, "$indent  ")
@@ -152,17 +168,17 @@ class CallTreeTest {
 
         buildAndCheckTree(
             """
-            [root]: 0 calls, 11 ns
-              simple1: 1 calls, 2 ns
-                simple2: 1 calls, 1 ns
-                  simple3: 1 calls, 1 ns
-              selfRecursion: 1 calls, 5 ns
-                selfRecursion: 1 calls, 3 ns
-                  selfRecursion: 1 calls, 1 ns
-              mutualRecursion1: 1 calls, 4 ns
-                mutualRecursion2: 1 calls, 3 ns
-                  mutualRecursion1: 1 calls, 2 ns
-                    mutualRecursion2: 1 calls, 1 ns
+            [root]: 0 calls, 15 ns, 15 ns
+              simple1: 2 calls, 6 ns, 4 ns
+                simple2: 3 calls, 5 ns, 3 ns
+                  simple3: 2 calls, 2 ns, 1 ns
+              selfRecursion: 1 calls, 5 ns, 5 ns
+                selfRecursion: 1 calls, 3 ns, 3 ns
+                  selfRecursion: 1 calls, 1 ns, 1 ns
+              mutualRecursion1: 1 calls, 4 ns, 4 ns
+                mutualRecursion2: 1 calls, 3 ns, 3 ns
+                  mutualRecursion1: 1 calls, 2 ns, 2 ns
+                    mutualRecursion2: 1 calls, 1 ns, 1 ns
             """.trimIndent()
         )
 
@@ -171,20 +187,20 @@ class CallTreeTest {
         builder.push(simple3); clock.time++
         buildAndCheckTree(
             """
-            [root]: 0 calls, 3 ns
-              simple1: 1 calls, 3 ns
-                simple2: 1 calls, 2 ns
-                  simple3: 1 calls, 1 ns
+            [root]: 0 calls, 3 ns, 3 ns
+              simple1: 1 calls, 3 ns, 3 ns
+                simple2: 1 calls, 2 ns, 2 ns
+                  simple3: 1 calls, 1 ns, 1 ns
             """.trimIndent()
         )
 
         clock.time += 10
         buildAndCheckTree(
             """
-            [root]: 0 calls, 10 ns
-              simple1: 0 calls, 10 ns
-                simple2: 0 calls, 10 ns
-                  simple3: 0 calls, 10 ns
+            [root]: 0 calls, 10 ns, 10 ns
+              simple1: 0 calls, 10 ns, 10 ns
+                simple2: 0 calls, 10 ns, 10 ns
+                  simple3: 0 calls, 10 ns, 10 ns
             """.trimIndent()
         )
     }


### PR DESCRIPTION
# Description

This will record worst-case timings for each traced method call (also called "maximum call time"). This is useful for keeping track of whether occassional bottlenecks occur in a method. I decided to display maximum call times as a column, thus allowing the user to sort traces by this new field.