### PR TITLE
Add untrace command

### DIFF
--- a/src/main/java/com/google/idea/perf/CallTreeBuilder.kt
+++ b/src/main/java/com/google/idea/perf/CallTreeBuilder.kt
@@ -129,11 +129,13 @@ class CallTreeBuilder(
         root = Tree(Tracepoint.ROOT, parent = null)
         root.startWallTime = oldRoot.startWallTime
         root.continuedWallTime = oldRoot.continuedWallTime
+        root.tracepointFlags = oldRoot.tracepointFlags
         currentNode = root
         for (node in stack.subList(1, stack.size)) {
             val copy = Tree(node.tracepoint, parent = currentNode)
             copy.startWallTime = node.startWallTime
             copy.continuedWallTime = node.continuedWallTime
+            copy.tracepointFlags = node.tracepointFlags
             currentNode.children[node.tracepoint] = copy
             currentNode = copy
         }

--- a/src/main/java/com/google/idea/perf/Tracepoint.kt
+++ b/src/main/java/com/google/idea/perf/Tracepoint.kt
@@ -31,7 +31,7 @@ class Tracepoint(
     val description: String? = null,
     flags: Int = TracepointFlags.TRACE_ALL
 ) {
-    var flags: AtomicInteger
+    val flags: AtomicInteger
 
     companion object {
         /** A special tracepoint representing the root of a call tree. */
@@ -57,6 +57,9 @@ class Tracepoint(
     fun unsetFlags(flags: Int) {
         this.flags.updateAndGet { it and flags.inv() }
     }
+
+    val isEnabled: Boolean
+        get() = (this.flags.get() and TracepointFlags.TRACE_ALL) != 0
 
     override fun toString(): String = displayName
 }

--- a/src/main/java/com/google/idea/perf/Tracepoint.kt
+++ b/src/main/java/com/google/idea/perf/Tracepoint.kt
@@ -29,8 +29,9 @@ object TracepointFlags {
 class Tracepoint(
     val displayName: String,
     val description: String? = null,
-    var flags: AtomicInteger = AtomicInteger(TracepointFlags.TRACE_ALL)
+    flags: Int = TracepointFlags.TRACE_ALL
 ) {
+    var flags: AtomicInteger
 
     companion object {
         /** A special tracepoint representing the root of a call tree. */
@@ -38,9 +39,11 @@ class Tracepoint(
     }
 
     init {
-        check((flags.get() and TracepointFlags.MASK.inv()) == 0) {
+        check((flags and TracepointFlags.MASK.inv()) == 0) {
             "Invalid tracepoint flags."
         }
+
+        this.flags = AtomicInteger(flags)
     }
 
     fun hasFlags(flags: Int): Boolean {

--- a/src/main/java/com/google/idea/perf/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/TracerConfig.kt
@@ -44,6 +44,7 @@ object TracerConfig {
             val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
             classConfig.methodNames.add(methodName)
 
+            // Re-enable tracepoints that were disabled via untrace.
             for ((signature, methodId) in classConfig.methodIds) {
                 if (signature.startsWith(methodName)) {
                     val tracepoint = getTracepoint(methodId)

--- a/src/main/java/com/google/idea/perf/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/TracerConfig.kt
@@ -46,7 +46,7 @@ object TracerConfig {
 
             // Re-enable tracepoints that were disabled via untrace.
             for ((signature, methodId) in classConfig.methodIds) {
-                if (signature.startsWith(methodName)) {
+                if (signature.substringBefore('(') == methodName) {
                     val tracepoint = getTracepoint(methodId)
                     tracepoint.setFlags(TracepointFlags.TRACE_ALL)
                 }
@@ -76,7 +76,7 @@ object TracerConfig {
             val classConfig = classConfigs[classJvmName] ?: return
 
             for ((signature, _) in classConfig.methodIds) {
-                if (signature.startsWith(methodName)) {
+                if (signature.substringBefore('(') == methodName) {
                     val methodDesc = signature.substring(methodName.length)
                     val methodId = getMethodId(classJvmName, methodName, methodDesc)
                     if (methodId != null) {

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -174,6 +174,17 @@ class TracerController(
             TracerConfig.traceMethods(classJvmName, methodName)
             retransformClasses(setOf(className))
         }
+        else if (cmd.startsWith("untrace")) {
+            val spec = cmd.substringAfter("untrace").trim()
+            val split = spec.split('#')
+            if (split.size != 2) {
+                LOG.warn("Invalid untrace format; expected com.example.Class#method")
+                return
+            }
+            val (className, methodName) = split
+            val classJvmName = className.replace('.', '/')
+            TracerConfig.untraceMethods(classJvmName, methodName)
+        }
         else if (cmd.contains('#')) {
             // Implicit trace command.
             handleCommand("trace $cmd")

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -184,6 +184,7 @@ class TracerController(
             val (className, methodName) = split
             val classJvmName = className.replace('.', '/')
             TracerConfig.untraceMethods(classJvmName, methodName)
+            retransformClasses(setOf(className))
         }
         else if (cmd.contains('#')) {
             // Implicit trace command.

--- a/src/main/java/com/google/idea/perf/TracerMethodTransformer.kt
+++ b/src/main/java/com/google/idea/perf/TracerMethodTransformer.kt
@@ -83,6 +83,11 @@ class TracerMethodTransformer : ClassFileTransformer {
             ): MethodVisitor? {
                 val methodWriter = cv.visitMethod(access, method, desc, signature, exceptions)
                 val id = TracerConfig.getMethodId(className, method, desc) ?: return methodWriter
+                val tracepoint = TracerConfig.getTracepoint(id)
+
+                if (!tracepoint.isEnabled) {
+                    return methodWriter
+                }
 
                 return object : AdviceAdapter(ASM_API, methodWriter, access, method, desc) {
                     val methodStart = Label()

--- a/src/test/java/com/google/idea/perf/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/CallTreeTest.kt
@@ -18,7 +18,6 @@ package com.google.idea.perf
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.util.concurrent.atomic.AtomicInteger
 
 class CallTreeTest {
 
@@ -222,7 +221,7 @@ class CallTreeTest {
     fun testConcurrentTracepointModification() {
         val clock = TestClock()
         val builder = CallTreeBuilder(clock)
-        val simple = Tracepoint("simple1", null, AtomicInteger(TracepointFlags.TRACE_ALL))
+        val simple = Tracepoint("simple1", null, TracepointFlags.TRACE_ALL)
 
         fun StringBuilder.printTree(node: CallTree, indent: String) {
             with(node) {


### PR DESCRIPTION
# Description

Adds the ability to untrace methods. Before figuring out the complete use case of this command, untracing as of this PR pauses the trace rather than removing it from the tracepoint table.

This PR implements the untrace command with tracepoint flags (see table below). This can later be used to implement partial tracing (e.g. only trace call counts).

| Tracepoint Flag | Description |
|----|----|
| TRACE_CALL_COUNT | Record method call counts |
| TRACE_WALL_TIME | Record total and maximum wall time |
| TRACE_ALL | Record all of the above |