### PR TITLE
Run CI workflow on both Linux and Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-2019]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
     steps:
     - name: Git checkout
       uses: actions/checkout@01aeccc # v2.1.0
@@ -18,18 +24,11 @@ jobs:
       with:
         java-version: 11.0.7
 
-    - name: Preload Gradle distribution
-      uses: actions/cache@70655ec # v1.1.2
-      with:
-        path: ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
-    - name: Preload Gradle caches
-      uses: actions/cache@70655ec # v1.1.2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: ${{ runner.os }}-gradle-caches
-
     - name: Build and test
-      run: CI=true ./gradlew build
+      uses: eskatos/gradle-command-action@c6b57b9 # v1.3.2
+      with:
+        arguments: build
+        wrapper-cache-enabled: true
+        dependencies-cache-enabled: true
+      env:
+        CI: true


### PR DESCRIPTION
We don't bother adding Mac for now because it's similar
enough to Linux.