### PR TITLE
Add tracer CLI parser

### DIFF
--- a/src/main/java/com/google/idea/perf/TracerCommand.kt
+++ b/src/main/java/com/google/idea/perf/TracerCommand.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf
+
+/** A tracer CLI command */
+sealed class TracerCommand {
+    /** Zero out all tracepoint data, but keep call tree. */
+    object Clear: TracerCommand()
+
+    /** Zero out all tracepoint data and reset the call tree. */
+    object Reset: TracerCommand()
+
+    /** Trace a set of methods. */
+    data class Trace(val traceOption: TraceOption?, val target: TraceTarget?): TracerCommand()
+
+    /** Untrace a set of methods. */
+    data class Untrace(val traceOption: TraceOption?, val target: TraceTarget?): TracerCommand()
+}
+
+/** Represents what to trace */
+sealed class TraceOption {
+    /** Option to trace all aspects of a method's execution. */
+    object All: TraceOption()
+
+    /** Option to trace the number of calls to a method. */
+    object CallCount: TraceOption()
+
+    /** Option to trace the execution time of a method. */
+    object WallTime: TraceOption()
+}
+
+/** A set of methods that the tracer will trace. */
+sealed class TraceTarget {
+    /** Trace the tracer's own internal methods. */
+    object Tracer: TraceTarget()
+
+    /** Trace some important methods of the PSI. */
+    object PsiFinders: TraceTarget()
+
+    /**
+     * Trace a specific method.
+     * @param className The Java class that contains the desired method
+     * @param methodName The method to trace
+     */
+    data class Method(val className: String, val methodName: String): TraceTarget()
+}

--- a/src/main/java/com/google/idea/perf/TracerCommand.kt
+++ b/src/main/java/com/google/idea/perf/TracerCommand.kt
@@ -33,15 +33,13 @@ sealed class TracerCommand {
 }
 
 /** Represents what to trace */
-sealed class TraceOption {
+enum class TraceOption {
     /** Option to trace all aspects of a method's execution. */
-    object All: TraceOption()
-
+    ALL,
     /** Option to trace the number of calls to a method. */
-    object CallCount: TraceOption()
-
+    CALL_COUNT,
     /** Option to trace the execution time of a method. */
-    object WallTime: TraceOption()
+    WALL_TIME
 }
 
 /** A set of methods that the tracer will trace. */
@@ -52,11 +50,7 @@ sealed class TraceTarget {
     /** Trace some important methods of the PSI. */
     object PsiFinders: TraceTarget()
 
-    /**
-     * Trace a specific method.
-     * @param className The Java class that contains the desired method
-     * @param methodName The method to trace
-     */
+    /** Trace a specific method. */
     data class Method(val className: String, val methodName: String): TraceTarget()
 }
 
@@ -79,7 +73,7 @@ fun parseTracerCommand(text: String): TracerCommand? {
 private fun parseTraceCommand(tokens: List<String>, enable: Boolean): TracerCommand? {
     return when (tokens.size) {
         0 -> TracerCommand.Trace(enable, null, null)
-        1 -> TracerCommand.Trace(enable, TraceOption.All, parseTraceTarget(tokens))
+        1 -> TracerCommand.Trace(enable, TraceOption.ALL, parseTraceTarget(tokens))
         else -> {
             val option = parseTraceOption(tokens)
             val target = parseTraceTarget(tokens.advance())
@@ -90,9 +84,9 @@ private fun parseTraceCommand(tokens: List<String>, enable: Boolean): TracerComm
 
 private fun parseTraceOption(tokens: List<String>): TraceOption? {
     return when (tokens.first()) {
-        "all" -> TraceOption.All
-        "count" -> TraceOption.CallCount
-        "wall-time" -> TraceOption.WallTime
+        "all" -> TraceOption.ALL
+        "count" -> TraceOption.CALL_COUNT
+        "wall-time" -> TraceOption.WALL_TIME
         else -> null
     }
 }
@@ -103,14 +97,13 @@ private fun parseTraceTarget(tokens: List<String>): TraceTarget? {
         "tracer" -> TraceTarget.Tracer
         else -> {
             val splitIndex = token.indexOf('#')
-            return if (splitIndex != -1) {
-                val className = token.substring(0, splitIndex)
-                val methodName = token.substring(splitIndex + 1)
-                TraceTarget.Method(className, methodName)
+            if (splitIndex == -1) {
+                return null
             }
-            else {
-                null
-            }
+
+            val className = token.substring(0, splitIndex)
+            val methodName = token.substring(splitIndex + 1)
+            TraceTarget.Method(className, methodName)
         }
     }
 }

--- a/src/main/java/com/google/idea/perf/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/TracerConfig.kt
@@ -88,6 +88,24 @@ object TracerConfig {
         }
     }
 
+    fun untraceMethod(method: Method) {
+        lock.withLock {
+            val classJvmName = method.declaringClass.name.replace('.', '/')
+            val methodDesc = Type.getMethodDescriptor(method)
+            untraceMethod(classJvmName, method.name, methodDesc)
+        }
+    }
+
+    private fun untraceMethod(classJvmName: String, methodName: String, methodDesc: String) {
+        lock.withLock {
+            val methodId = getMethodId(classJvmName, methodName, methodDesc)
+            if (methodId != null) {
+                val tracepoint = getTracepoint(methodId)
+                tracepoint.unsetFlags(TracepointFlags.TRACE_ALL)
+            }
+        }
+    }
+
     /** Remove all tracing and return the affected class names. */
     fun removeAllTracing(): List<String> {
         lock.withLock {

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -156,7 +156,7 @@ class TracerController(
                             traceAndRetransform(*methods.toTypedArray())
                         }
                         else {
-                            LOG.warn("Not implemented yet.")
+                            untraceAndRetransform(*methods.toTypedArray())
                         }
                     }
                     is TraceTarget.Tracer -> {
@@ -168,7 +168,11 @@ class TracerController(
                             )
                         }
                         else {
-                            LOG.warn("Not implemented yet.")
+                            untraceAndRetransform(
+                                TracerController::dataRefreshLoop.javaMethod!!,
+                                TracerController::updateTracepointUi.javaMethod!!,
+                                TracerController::handleCommand.javaMethod!!
+                            )
                         }
                     }
                     is TraceTarget.Method -> {
@@ -194,6 +198,13 @@ class TracerController(
     private fun traceAndRetransform(vararg methods: Method) {
         if (methods.isEmpty()) return
         methods.forEach(TracerConfig::traceMethod)
+        val classes = methods.map { it.declaringClass }.toSet()
+        retransformClasses(classes)
+    }
+
+    private fun untraceAndRetransform(vararg methods: Method) {
+        if (methods.isEmpty()) return
+        methods.forEach(TracerConfig::untraceMethod)
         val classes = methods.map { it.declaringClass }.toSet()
         retransformClasses(classes)
     }

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -152,28 +152,16 @@ class TracerController(
                         val methods = psiFinders.map {
                             it.javaClass.getMethod(baseMethod.name, *baseMethod.parameterTypes)
                         }
-                        if (command.enable) {
-                            traceAndRetransform(*methods.toTypedArray())
-                        }
-                        else {
-                            untraceAndRetransform(*methods.toTypedArray())
-                        }
+
+                        traceAndRetransform(command.enable, *methods.toTypedArray())
                     }
                     is TraceTarget.Tracer -> {
-                        if (command.enable) {
-                            traceAndRetransform(
-                                TracerController::dataRefreshLoop.javaMethod!!,
-                                TracerController::updateTracepointUi.javaMethod!!,
-                                TracerController::handleCommand.javaMethod!!
-                            )
-                        }
-                        else {
-                            untraceAndRetransform(
-                                TracerController::dataRefreshLoop.javaMethod!!,
-                                TracerController::updateTracepointUi.javaMethod!!,
-                                TracerController::handleCommand.javaMethod!!
-                            )
-                        }
+                        traceAndRetransform(
+                            command.enable,
+                            TracerController::dataRefreshLoop.javaMethod!!,
+                            TracerController::updateTracepointUi.javaMethod!!,
+                            TracerController::handleCommand.javaMethod!!
+                        )
                     }
                     is TraceTarget.Method -> {
                         val className = command.target.className
@@ -195,16 +183,14 @@ class TracerController(
         }
     }
 
-    private fun traceAndRetransform(vararg methods: Method) {
+    private fun traceAndRetransform(enable: Boolean, vararg methods: Method) {
         if (methods.isEmpty()) return
-        methods.forEach(TracerConfig::traceMethod)
-        val classes = methods.map { it.declaringClass }.toSet()
-        retransformClasses(classes)
-    }
-
-    private fun untraceAndRetransform(vararg methods: Method) {
-        if (methods.isEmpty()) return
-        methods.forEach(TracerConfig::untraceMethod)
+        if (enable) {
+            methods.forEach(TracerConfig::traceMethod)
+        }
+        else {
+            methods.forEach(TracerConfig::untraceMethod)
+        }
         val classes = methods.map { it.declaringClass }.toSet()
         retransformClasses(classes)
     }

--- a/src/test/java/com/google/idea/perf/TracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/TracerCommandTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+private fun assertCommand(expected: TracerCommand, actual: String) {
+    assertEquals(expected, parseTracerCommand(actual))
+}
+
+class TracerCommandTest {
+    @Test
+    fun testCommandParser() {
+        assertCommand(TracerCommand.Clear, "clear")
+        assertCommand(TracerCommand.Reset, "reset")
+
+        assertCommand(
+            TracerCommand.Trace(false, TraceOption.All, TraceTarget.PsiFinders),
+            "untrace psi-finders"
+        )
+
+        assertCommand(
+            TracerCommand.Trace(false, TraceOption.All, TraceTarget.Tracer),
+            "untrace tracer"
+        )
+
+        assertCommand(
+            TracerCommand.Trace(
+                false,
+                TraceOption.All,
+                TraceTarget.Method("com.example.MyAction", "actionPerformed")
+            ),
+            "untrace com.example.MyAction#actionPerformed"
+        )
+
+        assertCommand(
+            TracerCommand.Trace(true, TraceOption.All, TraceTarget.PsiFinders),
+            "trace psi-finders"
+        )
+
+        assertCommand(
+            TracerCommand.Trace(true, TraceOption.All, TraceTarget.Tracer),
+            "trace tracer"
+        )
+
+        assertCommand(
+            TracerCommand.Trace(
+                true,
+                TraceOption.All,
+                TraceTarget.Method("com.example.MyAction", "actionPerformed")
+            ),
+            "trace com.example.MyAction#actionPerformed"
+        )
+    }
+}

--- a/src/test/java/com/google/idea/perf/TracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/TracerCommandTest.kt
@@ -29,16 +29,23 @@ class TracerCommandTest {
         assertCommand(TracerCommand.Clear, "clear")
         assertCommand(TracerCommand.Reset, "reset")
 
+        // Untrace commands.
         assertCommand(
             TracerCommand.Trace(false, TraceOption.All, TraceTarget.PsiFinders),
             "untrace psi-finders"
         )
-
+        assertCommand(
+            TracerCommand.Trace(false, TraceOption.All, TraceTarget.PsiFinders),
+            "untrace all psi-finders"
+        )
         assertCommand(
             TracerCommand.Trace(false, TraceOption.All, TraceTarget.Tracer),
             "untrace tracer"
         )
-
+        assertCommand(
+            TracerCommand.Trace(false, TraceOption.CallCount, TraceTarget.Tracer),
+            "untrace count tracer"
+        )
         assertCommand(
             TracerCommand.Trace(
                 false,
@@ -47,17 +54,32 @@ class TracerCommandTest {
             ),
             "untrace com.example.MyAction#actionPerformed"
         )
+        assertCommand(
+            TracerCommand.Trace(
+                false,
+                TraceOption.WallTime,
+                TraceTarget.Method("com.example.MyAction", "actionPerformed")
+            ),
+            "untrace wall-time com.example.MyAction#actionPerformed"
+        )
 
+        // Trace commands.
         assertCommand(
             TracerCommand.Trace(true, TraceOption.All, TraceTarget.PsiFinders),
             "trace psi-finders"
         )
-
+        assertCommand(
+            TracerCommand.Trace(true, TraceOption.WallTime, TraceTarget.PsiFinders),
+            "trace wall-time psi-finders"
+        )
         assertCommand(
             TracerCommand.Trace(true, TraceOption.All, TraceTarget.Tracer),
             "trace tracer"
         )
-
+        assertCommand(
+            TracerCommand.Trace(true, TraceOption.CallCount, TraceTarget.Tracer),
+            "trace count tracer"
+        )
         assertCommand(
             TracerCommand.Trace(
                 true,
@@ -65,6 +87,14 @@ class TracerCommandTest {
                 TraceTarget.Method("com.example.MyAction", "actionPerformed")
             ),
             "trace com.example.MyAction#actionPerformed"
+        )
+        assertCommand(
+            TracerCommand.Trace(
+                true,
+                TraceOption.All,
+                TraceTarget.Method("com.example.MyAction", "actionPerformed")
+            ),
+            "trace all com.example.MyAction#actionPerformed"
         )
     }
 }

--- a/src/test/java/com/google/idea/perf/TracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/TracerCommandTest.kt
@@ -31,25 +31,25 @@ class TracerCommandTest {
 
         // Untrace commands.
         assertCommand(
-            TracerCommand.Trace(false, TraceOption.All, TraceTarget.PsiFinders),
+            TracerCommand.Trace(false, TraceOption.ALL, TraceTarget.PsiFinders),
             "untrace psi-finders"
         )
         assertCommand(
-            TracerCommand.Trace(false, TraceOption.All, TraceTarget.PsiFinders),
+            TracerCommand.Trace(false, TraceOption.ALL, TraceTarget.PsiFinders),
             "untrace all psi-finders"
         )
         assertCommand(
-            TracerCommand.Trace(false, TraceOption.All, TraceTarget.Tracer),
+            TracerCommand.Trace(false, TraceOption.ALL, TraceTarget.Tracer),
             "untrace tracer"
         )
         assertCommand(
-            TracerCommand.Trace(false, TraceOption.CallCount, TraceTarget.Tracer),
+            TracerCommand.Trace(false, TraceOption.CALL_COUNT, TraceTarget.Tracer),
             "untrace count tracer"
         )
         assertCommand(
             TracerCommand.Trace(
                 false,
-                TraceOption.All,
+                TraceOption.ALL,
                 TraceTarget.Method("com.example.MyAction", "actionPerformed")
             ),
             "untrace com.example.MyAction#actionPerformed"
@@ -57,7 +57,7 @@ class TracerCommandTest {
         assertCommand(
             TracerCommand.Trace(
                 false,
-                TraceOption.WallTime,
+                TraceOption.WALL_TIME,
                 TraceTarget.Method("com.example.MyAction", "actionPerformed")
             ),
             "untrace wall-time com.example.MyAction#actionPerformed"
@@ -65,25 +65,25 @@ class TracerCommandTest {
 
         // Trace commands.
         assertCommand(
-            TracerCommand.Trace(true, TraceOption.All, TraceTarget.PsiFinders),
+            TracerCommand.Trace(true, TraceOption.ALL, TraceTarget.PsiFinders),
             "trace psi-finders"
         )
         assertCommand(
-            TracerCommand.Trace(true, TraceOption.WallTime, TraceTarget.PsiFinders),
+            TracerCommand.Trace(true, TraceOption.WALL_TIME, TraceTarget.PsiFinders),
             "trace wall-time psi-finders"
         )
         assertCommand(
-            TracerCommand.Trace(true, TraceOption.All, TraceTarget.Tracer),
+            TracerCommand.Trace(true, TraceOption.ALL, TraceTarget.Tracer),
             "trace tracer"
         )
         assertCommand(
-            TracerCommand.Trace(true, TraceOption.CallCount, TraceTarget.Tracer),
+            TracerCommand.Trace(true, TraceOption.CALL_COUNT, TraceTarget.Tracer),
             "trace count tracer"
         )
         assertCommand(
             TracerCommand.Trace(
                 true,
-                TraceOption.All,
+                TraceOption.ALL,
                 TraceTarget.Method("com.example.MyAction", "actionPerformed")
             ),
             "trace com.example.MyAction#actionPerformed"
@@ -91,7 +91,7 @@ class TracerCommandTest {
         assertCommand(
             TracerCommand.Trace(
                 true,
-                TraceOption.All,
+                TraceOption.ALL,
                 TraceTarget.Method("com.example.MyAction", "actionPerformed")
             ),
             "trace all com.example.MyAction#actionPerformed"


### PR DESCRIPTION
# Description

Refactor current implementation of CLI parser with a single function called `parseTracerCommand`. To keep things simple, this function directly returns a usable `TracerCommand?` object rather than a full-blown parse tree. This parser will be useful for later expanding on commands and adding autocompletion.

# Todos (for later PRs)

- Wildcards (e.g. `untrace *` disables all tracepoints).
- Automatic suggestions. For simplicity, `parseTracerCommand` will, on demand, return an additional value that contains suggestions (maybe an cancellable future object?).
- While the parser supports partial trace commands, the controller still needs to recognize them.

# Questions

These are questions I asked and answered to myself, but feel free to give your input on them!

> If you give the parser a syntactically invalid command, what should the parser return?

**Some induction:** There are many different kinds of errors a parser can encounter. In particular, one kind of error I may have an answer to are incomplete commands (e.g. `trace wall-time`). In this case, some properties in the resulting command object will be null.

**Decision:** To stay consistent with how the parser handles incomplete commands, the parser should generally try its best to build command objects on commands with other kinds of errors. One thing that's missing is returning error messages, but that can come in at a later pull request.

**Foreshadowing:** Also, these nullable values will later be useful for implementing automatic suggestions without touching the parser code. We want to decouple parsing and automatic suggestions as much as possible.

> Why doesn't the command grammar follow the usual shell conventions?

- **Keyboard ergonomics:** I wanted to avoid making the user type in `--` before every option.
- **Ease of use:** I forced options to go in a specific order. It's easier for the user to discover and categorize options based on automatic suggestions, and it's easier to implement.