### PR TITLE
Improve fuzzy search performance

### DIFF
--- a/src/main/java/com/google/idea/perf/Autocomplete.kt
+++ b/src/main/java/com/google/idea/perf/Autocomplete.kt
@@ -66,7 +66,7 @@ class Autocomplete {
         nameFunc: (MatchResult) -> String,
         detailFunc: (MatchResult) -> String?
     ): List<Suggestion> {
-        return fuzzySearch(choices, token) { ProgressManager.checkCanceled() }
+        return fuzzySearch(choices, token, 100) { ProgressManager.checkCanceled() }
             .map { Suggestion(nameFunc(it), detailFunc(it)) }
     }
 

--- a/src/main/java/com/google/idea/perf/Matching.kt
+++ b/src/main/java/com/google/idea/perf/Matching.kt
@@ -87,11 +87,11 @@ fun fuzzyMatch(source: String, pattern: String): Boolean {
 
 /* Base scores */
 private const val GAP_SCORE = -1
-private const val MATCH_SCORE = -GAP_SCORE * 8
+private const val MATCH_SCORE = -GAP_SCORE * 4
 private const val MISMATCH_SCORE = -MATCH_SCORE
 
 /* Constants for super scores */
-private const val GAP_RECOVERY_SCORE = MATCH_SCORE * 2
+private const val GAP_RECOVERY_SCORE = MATCH_SCORE
 
 /*
  * Super scores

--- a/src/main/java/com/google/idea/perf/util/LruCache.kt
+++ b/src/main/java/com/google/idea/perf/util/LruCache.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.util
+
+private class Node<K:Any, V: Any>(var key: K, var value: V) {
+    var next: Node<K, V>? = null
+    var previous: Node<K, V>? = null
+}
+
+class LruCache<K: Any, V: Any>(private val maxCapacity: Int = 0) {
+    private val nodes = HashMap<K, Node<K, V>>(maxCapacity)
+    private var head: Node<K, V>? = null
+    private var tail: Node<K, V>? = null
+
+    init {
+        check(maxCapacity > 0) { "maxCapacity must be a value greater than zero." }
+    }
+
+    operator fun get(key: K): V? {
+        val node = nodes[key] ?: return null
+        val value = node.value
+
+        if (node != head) {
+            if (node.next != null && node.previous != null) {
+                val next = node.next
+                val previous = node.previous
+                next!!.previous = previous
+                previous!!.next = next
+            }
+            else if (node.previous != null) {
+                val previous = node.previous
+                previous!!.next = null
+                tail = previous
+            }
+
+            node.next = head
+            node.previous = null
+            head!!.previous = node
+            head = node
+        }
+
+        return value
+    }
+
+    operator fun set(key: K, value: V) {
+        if (nodes.size >= maxCapacity) {
+            if (nodes.size != 1) {
+                nodes.remove(tail!!.key)
+                tail = tail!!.previous
+                tail!!.next = null
+            }
+            else {
+                nodes.clear()
+                head = null
+                tail = null
+            }
+        }
+
+        var node = nodes[key]
+
+        if (node != null) {
+            node.value = value
+            get(key)
+        }
+        else {
+            node = Node(key, value)
+            node.next = head
+            nodes[key] = node
+
+            if (head != null) {
+                head!!.previous = node
+                head = node
+            }
+            else {
+                head = node
+                tail = node
+            }
+        }
+    }
+
+    fun put(key: K, value: V) = set(key, value)
+
+    fun computeIfAbsent(key: K, mappingFunction: (K) -> V) {
+        if (!nodes.containsKey(key)) {
+            put(key, mappingFunction(key))
+        }
+    }
+}

--- a/src/test/java/com/google/idea/perf/LruCacheTest.kt
+++ b/src/test/java/com/google/idea/perf/LruCacheTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf
+
+import com.google.idea.perf.util.LruCache
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class LruCacheTest {
+    @Test
+    fun testCache() {
+        // Cache with a max capacity of one element.
+        var cache = LruCache<String, String>(1)
+        cache["A"] = "100"
+        for (i in 0..1) {
+            assertEquals("100", cache["A"])
+            assertEquals(null, cache["B"])
+        }
+
+        // Query cache below maximum capacity
+        cache = LruCache(4)
+        cache["A"] = "100"
+        cache["B"] = "200"
+        cache["C"] = "300"
+        for (i in 0..1) {
+            assertEquals("100", cache["A"])
+            assertEquals("200", cache["B"])
+            assertEquals("300", cache["C"])
+            assertEquals(null, cache["D"])
+        }
+
+        // Query cache at maximum capacity
+        cache = LruCache(4)
+        cache["A"] = "100"
+        cache["B"] = "200"
+        cache["C"] = "300"
+        cache["D"] = "400"
+        for (i in 0..1) {
+            assertEquals("100", cache["A"])
+            assertEquals("200", cache["B"])
+            assertEquals("300", cache["C"])
+            assertEquals("400", cache["D"])
+            assertEquals(null, cache["E"])
+        }
+
+        // Query cache beyond maximum capacity
+        cache = LruCache(4)
+        cache["A"] = "100"
+        cache["B"] = "200"
+        cache["C"] = "300"
+        cache["D"] = "400"
+        cache["E"] = "500"
+        assertEquals(null, cache["A"])
+        assertEquals("200", cache["B"])
+        assertEquals("300", cache["C"])
+        assertEquals("400", cache["D"])
+        assertEquals("500", cache["E"])
+
+        cache["A"] = "100"
+        assertEquals("100", cache["A"])
+        assertEquals(null, cache["B"])
+        assertEquals("300", cache["C"])
+        assertEquals("400", cache["D"])
+        assertEquals("500", cache["E"])
+
+        cache["D"] = "400"
+        assertEquals(null, cache["A"])
+        assertEquals(null, cache["B"])
+        assertEquals("300", cache["C"])
+        assertEquals("400", cache["D"])
+        assertEquals("500", cache["E"])
+    }
+}

--- a/src/test/java/com/google/idea/perf/MatchingTest.kt
+++ b/src/test/java/com/google/idea/perf/MatchingTest.kt
@@ -18,21 +18,136 @@ package com.google.idea.perf
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 private fun assertMatch(expectMatch: Boolean, source: String, pattern: String) {
     assertEquals(expectMatch, fuzzyMatch(source, pattern))
 }
 
+private fun assertSearch(
+    patterns: List<String>,
+    expectedMatches: List<String>,
+    items: List<String>
+) {
+    for (pattern in patterns) {
+        val matches = fuzzySearch(items, pattern, -1) {}.map { it.source }
+        assertTrue(matches.containsAll(expectedMatches))
+    }
+}
+
+private val idePerfClasses = listOf(
+    "com.google.idea.perf.AgentLoader",
+    "com.google.idea.perf.CallTreeBuilder",
+    "com.google.idea.perf.CallTreeManager",
+    "com.google.idea.perf.TracerConfig",
+    "com.google.idea.perf.TracerController",
+    "com.google.idea.perf.TracerMethodTransformer"
+)
+
+private val javaLangClasses = listOf(
+    "java.lang.Boolean",
+    "java.lang.Byte",
+    "java.lang.Character",
+    "java.lang.Character\$Subset",
+    "java.lang.Character\$UnicodeBlock",
+    "java.lang.Class",
+    "java.lang.ClassLoader",
+    "java.lang.ClassValue",
+    "java.lang.Compiler",
+    "java.lang.Double",
+    "java.lang.Enum",
+    "java.lang.Float",
+    "java.lang.InheritableThreadLocal",
+    "java.lang.Integer",
+    "java.lang.Long",
+    "java.lang.Math",
+    "java.lang.Number",
+    "java.lang.Object",
+    "java.lang.Package",
+    "java.lang.Process",
+    "java.lang.ProcessBuilder",
+    "java.lang.ProcessBuilder\$Redirect",
+    "java.lang.Runtime",
+    "java.lang.RuntimePermission",
+    "java.lang.SecurityManager",
+    "java.lang.Short",
+    "java.lang.StackTraceElement",
+    "java.lang.StrictMath",
+    "java.lang.String",
+    "java.lang.StringBuffer",
+    "java.lang.StringBuilder",
+    "java.lang.System",
+    "java.lang.Thread",
+    "java.lang.ThreadGroup",
+    "java.lang.ThreadLocal",
+    "java.lang.Throwable",
+    "java.lang.Void"
+)
+
+private val allSampleClasses = idePerfClasses + javaLangClasses
+
+@Suppress("SpellCheckingInspection")
 class MatchingTest {
-    @Suppress("SpellCheckingInspection")
     @Test
-    fun testFuzzyMatcher() {
+    fun testFuzzyMatch() {
         assertMatch(true, "java.lang.String", "java.lang.String")
         assertMatch(true, "java.lang.String", "javalangString")
         assertMatch(true, "java.lang.String", "String")
-        assertMatch(true, "java.lang.String", "Strng")
         assertMatch(true, "java.lang.String", "Str")
+        assertMatch(true, "java.lang.String", "tring")
+        assertMatch(true, "java.lang.String", "ing")
         assertMatch(false, "java.lang.String", "$$$$$$$$$$")
         assertMatch(false, "java.lang.String", "          ")
+    }
+
+    @Test
+    fun testFuzzySearch() {
+        // Package search
+        assertSearch(
+            listOf(
+                "com.google.idea.perf.",
+                "com.google.idea.perf",
+                "com.google.idea.",
+                "com.google.idea",
+                "com.google.",
+                "com.google"
+            ),
+            idePerfClasses,
+            allSampleClasses
+        )
+
+        assertSearch(
+            listOf("java.lang.", "java.lang", "java.", "java"),
+            javaLangClasses,
+            allSampleClasses
+        )
+
+        // Class search
+        assertSearch(
+            listOf("Tracer"),
+            listOf(
+                "com.google.idea.perf.TracerConfig",
+                "com.google.idea.perf.TracerController",
+                "com.google.idea.perf.TracerMethodTransformer"
+            ),
+            allSampleClasses
+        )
+
+        assertSearch(
+            listOf(
+                "java.lang.String",
+                "String",
+                "Strin",
+                "Str",
+                "tring",
+                "ing"
+            ),
+            listOf(
+                "java.lang.String",
+                "java.lang.StringBuffer",
+                "java.lang.StringBuilder"
+            ),
+            allSampleClasses
+        )
     }
 }


### PR DESCRIPTION
# Description

- Introduced a search cache. The cached search algorithm feeds previous search results back into the input.
- Add unit tests for fuzzy search.
- Refactored fuzzy search into a class. This will later be used for benchmarking. `fuzzySearch` still exists for primary usage.