### PR TITLE
Make refinements

### DIFF
--- a/agent/src/main/java/com/google/idea/perf/agent/MethodListener.java
+++ b/agent/src/main/java/com/google/idea/perf/agent/MethodListener.java
@@ -18,6 +18,6 @@ package com.google.idea.perf.agent;
 
 /** Handler for method entry/exit events coming from instrumented bytecode. */
 public interface MethodListener {
-    void enter(int methodId, Object[] args);
+    void enter(int methodId, Argument[] args);
     void leave(int methodId);
 }

--- a/agent/src/main/java/com/google/idea/perf/agent/Trampoline.java
+++ b/agent/src/main/java/com/google/idea/perf/agent/Trampoline.java
@@ -27,7 +27,7 @@ public class Trampoline {
     public static MethodListener methodListener; // Set by the tracer.
 
     // These methods are called from instrumented bytecode.
-    public static void enter(int methodId, Object[] args) {
+    public static void enter(int methodId, Argument[] args) {
         methodListener.enter(methodId, args);
     }
 

--- a/src/main/java/com/google/idea/perf/CommandCompletionProvider.kt
+++ b/src/main/java/com/google/idea/perf/CommandCompletionProvider.kt
@@ -16,6 +16,7 @@
 
 package com.google.idea.perf
 
+import com.google.idea.perf.util.fuzzyMatch
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionUtilCore

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -52,7 +52,10 @@ abstract class TracerController(
         executor.scheduleWithFixedDelay(
             this::dataRefreshLoop, 0, REFRESH_DELAY_MS, MILLISECONDS
         )
+        start()
     }
+
+    abstract fun start()
 
     protected fun dataRefreshLoop() {
         val startTime = System.nanoTime()

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -52,10 +52,11 @@ abstract class TracerController(
         executor.scheduleWithFixedDelay(
             this::dataRefreshLoop, 0, REFRESH_DELAY_MS, MILLISECONDS
         )
-        start()
+        onControllerInitialize()
     }
 
-    abstract fun start()
+    /** Called after the controller has been initialized. */
+    abstract fun onControllerInitialize()
 
     protected fun dataRefreshLoop() {
         val startTime = System.nanoTime()

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -84,7 +84,7 @@ abstract class TracerController(
         return ProgressManager.getInstance().runProcess(computable, progress)
     }
 
-    protected class MyProgressIndicator(private val view: TracerView) : ProgressIndicatorBase() {
+    protected class MyProgressIndicator(private val view: TracerView): ProgressIndicatorBase() {
         override fun onRunningChange(): Unit = onChange()
 
         override fun onProgressChange(): Unit = onChange()

--- a/src/main/java/com/google/idea/perf/TracerView.kt
+++ b/src/main/java/com/google/idea/perf/TracerView.kt
@@ -16,6 +16,8 @@
 
 package com.google.idea.perf
 
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.ui.popup.util.PopupUtil
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.textCompletion.TextFieldWithCompletion
@@ -26,4 +28,8 @@ abstract class TracerView: JBPanel<TracerView>() {
     abstract val commandLine: TextFieldWithCompletion
     abstract val progressBar: JProgressBar
     abstract val refreshTimeLabel: JBLabel
+
+    fun showCommandBalloon(message: String, type: MessageType) {
+        PopupUtil.showBalloonForComponent(commandLine, message, type, true, null)
+    }
 }

--- a/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerCommandPredictor.kt
@@ -17,7 +17,7 @@
 package com.google.idea.perf.cachedvaluetracer
 
 import com.google.idea.perf.CommandPredictor
-import com.google.idea.perf.fuzzySearch
+import com.google.idea.perf.util.fuzzySearch
 import com.intellij.openapi.progress.ProgressManager
 
 class CachedValueTracerCommandPredictor: CommandPredictor {

--- a/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerController.kt
+++ b/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerController.kt
@@ -18,8 +18,8 @@ package com.google.idea.perf.cachedvaluetracer
 
 import com.google.idea.perf.CommandCompletionProvider
 import com.google.idea.perf.TracerController
-import com.google.idea.perf.fuzzyMatch
 import com.google.idea.perf.methodtracer.AgentLoader
+import com.google.idea.perf.util.fuzzyMatch
 import com.google.idea.perf.util.sumByLong
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager.getApplication

--- a/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerController.kt
+++ b/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerController.kt
@@ -53,7 +53,7 @@ class CachedValueTracerController(
         CachedValueProfiler.getInstance().isEnabled = false
     }
 
-    override fun start() {
+    override fun onControllerInitialize() {
         executor.scheduleWithFixedDelay(
             this::reloadAutocompleteClasses, 0L, AUTOCOMPLETE_RELOAD_INTERVAL, SECONDS
         )

--- a/src/main/java/com/google/idea/perf/methodtracer/AgentLoader.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/AgentLoader.kt
@@ -108,11 +108,9 @@ object AgentLoader {
     /** Dispatches method entry/exit events to the [CallTreeManager]. */
     private class TracerMethodListener: MethodListener {
 
-        override fun enter(methodId: Int, args: Array<Any>?) {
+        override fun enter(methodId: Int, args: Array<Argument>?) {
             val tracepoint = TracerConfig.getTracepoint(methodId)
-
-            @Suppress("UNCHECKED_CAST")
-            CallTreeManager.enter(tracepoint, args as Array<Argument>?)
+            CallTreeManager.enter(tracepoint, args)
         }
 
         override fun leave(methodId: Int) {

--- a/src/main/java/com/google/idea/perf/methodtracer/AgentLoader.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/AgentLoader.kt
@@ -45,7 +45,8 @@ object AgentLoader {
             // classes---otherwise NoClassDefFoundError is imminent. So we use reflection.
             Class.forName("com.google.idea.perf.agent.AgentMain", false, null)
             true
-        } catch (e: ClassNotFoundException) {
+        }
+        catch (e: ClassNotFoundException) {
             false
         }
 
@@ -53,12 +54,14 @@ object AgentLoader {
         if (agentLoadedAtStartup) {
             instrumentation = checkNotNull(AgentMain.savedInstrumentationInstance)
             LOG.info("Agent was loaded at startup")
-        } else {
+        }
+        else {
             try {
                 tryLoadAgentAfterStartup()
                 instrumentation = checkNotNull(AgentMain.savedInstrumentationInstance)
                 LOG.info("Agent was loaded on demand")
-            } catch (e: Throwable) {
+            }
+            catch (e: Throwable) {
                 val msg = """
                     [Tracer] Failed to attach the instrumentation agent after startup.
                     On JDK 9+, make sure jdk.attach.allowAttachSelf is set to true.
@@ -96,13 +99,14 @@ object AgentLoader {
         val vm = VirtualMachine.attach(OSProcessUtil.getApplicationPid())
         try {
             vm.loadAgent(agentJar.absolutePath)
-        } finally {
+        }
+        finally {
             vm.detach()
         }
     }
 
     /** Dispatches method entry/exit events to the [CallTreeManager]. */
-    private class TracerMethodListener : MethodListener {
+    private class TracerMethodListener: MethodListener {
 
         override fun enter(methodId: Int, args: Array<Any>?) {
             val tracepoint = TracerConfig.getTracepoint(methodId)

--- a/src/main/java/com/google/idea/perf/methodtracer/ArgSetTable.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/ArgSetTable.kt
@@ -98,7 +98,7 @@ class ArgSetTable(private val model: ArgSetTableModel): JBTable(model) {
             // Locale-aware and unit-aware rendering for numbers.
             when (col) {
                 CALLS, WALL_TIME, MAX_WALL_TIME -> {
-                    tableColumn.cellRenderer = object : DefaultTableCellRenderer() {
+                    tableColumn.cellRenderer = object: DefaultTableCellRenderer() {
                         init {
                             horizontalAlignment = SwingConstants.RIGHT
                         }
@@ -120,7 +120,7 @@ class ArgSetTable(private val model: ArgSetTableModel): JBTable(model) {
         }
 
         // Limit sorting directions.
-        rowSorter = object : TableRowSorter<ArgSetTableModel>(model) {
+        rowSorter = object: TableRowSorter<ArgSetTableModel>(model) {
             override fun toggleSortOrder(col: Int) {
                 val alreadySorted = sortKeys.any {
                     it.column == col && it.sortOrder != SortOrder.UNSORTED
@@ -137,7 +137,7 @@ class ArgSetTable(private val model: ArgSetTableModel): JBTable(model) {
     }
 
     override fun createDefaultTableHeader(): JTableHeader {
-        return object : JBTableHeader() {
+        return object: JBTableHeader() {
             init {
                 // Override the renderer that JBTableHeader sets.
                 // The default, center-aligned renderer looks better.

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTreeBuilder.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTreeBuilder.kt
@@ -45,14 +45,14 @@ class CallTreeBuilder(
         fun sample(): Long
     }
 
-    object SystemClock : Clock {
+    object SystemClock: Clock {
         override fun sample(): Long = System.nanoTime()
     }
 
     private class Tree(
         override val tracepoint: Tracepoint,
         val parent: Tree?
-    ) : CallTree {
+    ): CallTree {
         class MutableStats(
             override var callCount: Long = 0L,
             override var wallTime: Long = 0L,

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTreeManager.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTreeManager.kt
@@ -68,7 +68,8 @@ object CallTreeManager {
             state.busy = true
             try {
                 action()
-            } finally {
+            }
+            finally {
                 state.busy = false
             }
         }

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommand.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommand.kt
@@ -39,7 +39,14 @@ enum class TraceOption {
     /** Option to trace the number of calls to a method. */
     CALL_COUNT,
     /** Option to trace the execution time of a method. */
-    WALL_TIME
+    WALL_TIME;
+
+    val tracepointFlag: Int
+        get() = when (this) {
+            ALL -> TracepointFlags.TRACE_ALL
+            CALL_COUNT -> TracepointFlags.TRACE_CALL_COUNT
+            WALL_TIME -> TracepointFlags.TRACE_WALL_TIME
+        }
 }
 
 /** A set of methods that the tracer will trace. */

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommand.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommand.kt
@@ -155,6 +155,8 @@ private fun parseTraceTarget(tokens: List<Token>): TraceTarget? {
                 TraceTarget.Method(first.textString, third.textString, parseParameterList(tokens.advance(4)))
             second is HashSymbol && third is Identifier ->
                 TraceTarget.Method(first.textString, third.textString, emptyList())
+            second is HashSymbol ->
+                TraceTarget.Method(first.textString, "", null)
             else -> TraceTarget.Method(first.textString, null, null)
         }
         else -> null

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
@@ -17,7 +17,7 @@
 package com.google.idea.perf.methodtracer
 
 import com.google.idea.perf.CommandPredictor
-import com.google.idea.perf.fuzzySearch
+import com.google.idea.perf.util.fuzzySearch
 import com.intellij.openapi.progress.ProgressManager
 
 class MethodTracerCommandPredictor: CommandPredictor {

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
@@ -47,18 +47,23 @@ class MethodTracerCommandPredictor: CommandPredictor {
                 }
                 else -> emptyList()
             }
-            2 -> when {
-                command is MethodTracerCommand.Trace && command.target is TraceTarget.Method ->
-                    predictMethodToken(command.target.className, token)
-                command is MethodTracerCommand.Trace -> predictToken(classNames, token)
-                else -> emptyList()
-            }
-            3 -> when {
-                command is MethodTracerCommand.Trace && command.target is TraceTarget.Method ->
-                    predictMethodToken(command.target.className, token)
+            2, 3 -> when (command) {
+                is MethodTracerCommand.Trace -> predictClassOrMethod(command, token)
                 else -> emptyList()
             }
             else -> emptyList()
+        }
+    }
+
+    private fun predictClassOrMethod(
+        command: MethodTracerCommand.Trace, token: String
+    ): List<String> {
+        val target = command.target
+        return if (target is TraceTarget.Method && target.className.isNotBlank()) {
+            predictMethodToken(target.className, token)
+        }
+        else {
+            predictToken(classNames, token)
         }
     }
 

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
@@ -68,9 +68,14 @@ class MethodTracerCommandPredictor: CommandPredictor {
     }
 
     private fun predictMethodToken(className: String, token: String): List<String> {
-        val clazz = Class.forName(className)
-        val methodNames = clazz.methods.map { it.name.substringAfter('$') }
-        return predictToken(methodNames, token)
+        return try {
+            val clazz = Class.forName(className)
+            val methodNames = clazz.methods.map { it.name.substringAfter('$') }
+            predictToken(methodNames, token)
+        }
+        catch (ex: ClassNotFoundException) {
+            emptyList()
+        }
     }
 
     private fun getTokenIndex(input: String, index: Int): Int {

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -138,6 +138,15 @@ class MethodTracerController(
                             this::handleCommand.javaMethod!!
                         )
                     }
+                    is TraceTarget.All -> {
+                        if (command.enable) {
+                            LOG.warn("Tracing all methods is prohibited.")
+                        }
+                        else {
+                            val classNames = TracerConfig.removeAllTracing()
+                            retransformClasses(classNames.toSet())
+                        }
+                    }
                     is TraceTarget.Method -> {
                         val traceOption = command.traceOption
                         val className = command.target.className

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -68,7 +68,7 @@ class MethodTracerController(
         parentDisposable.attachChild(this)
     }
 
-    override fun start() {
+    override fun onControllerInitialize() {
         executor.scheduleWithFixedDelay(
             this::reloadAutocompleteClasses, 0L, AUTOCOMPLETE_RELOAD_INTERVAL, SECONDS
         )

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -142,7 +142,7 @@ class MethodTracerController(
                         val traceOption = command.traceOption
                         val className = command.target.className
                         val methodName = command.target.methodName
-                        val parameters = command.target.parameterIndexes?.map { it.index }
+                        val parameters = command.target.parameterIndexes
                         val classJvmName = className.replace('.', '/')
                         if (traceOption != null && methodName != null && parameters != null) {
                             if (command.enable) {

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -139,16 +139,17 @@ class MethodTracerController(
                         )
                     }
                     is TraceTarget.Method -> {
+                        val traceOption = command.traceOption
                         val className = command.target.className
                         val methodName = command.target.methodName
                         val parameters = command.target.parameterIndexes?.map { it.index }
                         val classJvmName = className.replace('.', '/')
-                        if (methodName != null && parameters != null) {
+                        if (traceOption != null && methodName != null && parameters != null) {
                             if (command.enable) {
                                 TracerConfig.traceMethods(
                                     classJvmName,
                                     methodName,
-                                    TracepointFlags.TRACE_ALL,
+                                    traceOption.tracepointFlag,
                                     parameters
                                 )
                             }

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -92,7 +92,8 @@ class MethodTracerController(
             // Special case: handle this command while we're still on the EDT.
             val path = cmd.substringAfter("save").trim()
             savePngFromEdt(path)
-        } else {
+        }
+        else {
             executor.execute { handleCommand(cmd) }
         }
     }
@@ -189,9 +190,11 @@ class MethodTracerController(
                 progress.checkCanceled()
                 try {
                     instrumentation.retransformClasses(clazz)
-                } catch (e: UnmodifiableClassException) {
+                }
+                catch (e: UnmodifiableClassException) {
                     LOG.warn("Cannot instrument non-modifiable class: ${clazz.name}")
-                } catch (e: Throwable) {
+                }
+                catch (e: Throwable) {
                     LOG.error("Failed to retransform class: ${clazz.name}", e)
                 }
                 if (!progress.isIndeterminate) {
@@ -217,7 +220,8 @@ class MethodTracerController(
         getApplication().executeOnPooledThread {
             try {
                 ImageIO.write(img, "png", file)
-            } catch (e: IOException) {
+            }
+            catch (e: IOException) {
                 LOG.warn("Failed to write png to $path", e)
             }
         }

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerView.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerView.kt
@@ -45,7 +45,7 @@ import javax.swing.border.Border
 // - DialogWrapper wrapper is still tied to a specific project window.
 
 /** Invoked by the user via the "Trace" action. */
-class MethodTracerAction : DumbAwareAction() {
+class MethodTracerAction: DumbAwareAction() {
     private var currentTracer: MethodTracerDialog? = null
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -53,7 +53,8 @@ class MethodTracerAction : DumbAwareAction() {
         if (tracer != null) {
             check(!tracer.isDisposed)
             tracer.toFront()
-        } else {
+        }
+        else {
             val newTracer = MethodTracerDialog()
             currentTracer = newTracer
             newTracer.disposable.attach { currentTracer = null }
@@ -63,7 +64,7 @@ class MethodTracerAction : DumbAwareAction() {
 }
 
 /** The dialog window that pops up via the "Trace" action. */
-class MethodTracerDialog : DialogWrapper(null, null, false, IdeModalityType.IDE, false) {
+class MethodTracerDialog: DialogWrapper(null, null, false, IdeModalityType.IDE, false) {
     init {
         title = "Tracer"
         isModal = false
@@ -77,7 +78,7 @@ class MethodTracerDialog : DialogWrapper(null, null, false, IdeModalityType.IDE,
 }
 
 /** The content filling the tracer dialog window. */
-class MethodTracerView(parentDisposable: Disposable) : TracerView() {
+class MethodTracerView(parentDisposable: Disposable): TracerView() {
     private val controller = MethodTracerController(this, parentDisposable)
     override val commandLine: TextFieldWithCompletion
     override val progressBar: JProgressBar

--- a/src/main/java/com/google/idea/perf/methodtracer/TracepointTable.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracepointTable.kt
@@ -41,7 +41,7 @@ private const val MAX_WALL_TIME = 3
 private const val COL_COUNT = 4
 
 /** The table model for [TracepointTable]. */
-class TracepointTableModel : AbstractTableModel() {
+class TracepointTableModel: AbstractTableModel() {
     private var data: List<TracepointStats>? = null
 
     fun setTracepointStats(newStats: List<TracepointStats>?) {
@@ -82,7 +82,7 @@ class TracepointTableModel : AbstractTableModel() {
 }
 
 /** Displays a list of tracepoints alongside their call counts and timing measurements. */
-class TracepointTable(private val model: TracepointTableModel) : JBTable(model) {
+class TracepointTable(private val model: TracepointTableModel): JBTable(model) {
 
     init {
         font = JBUI.Fonts.create(Font.MONOSPACED, font.size)
@@ -105,7 +105,7 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
             // Locale-aware and unit-aware rendering for numbers.
             when (col) {
                 CALLS, WALL_TIME, MAX_WALL_TIME -> {
-                    tableColumn.cellRenderer = object : DefaultTableCellRenderer() {
+                    tableColumn.cellRenderer = object: DefaultTableCellRenderer() {
                         init {
                             horizontalAlignment = SwingConstants.RIGHT
                         }
@@ -127,7 +127,7 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
         }
 
         // Limit sorting directions.
-        rowSorter = object : TableRowSorter<TracepointTableModel>(model) {
+        rowSorter = object: TableRowSorter<TracepointTableModel>(model) {
             override fun toggleSortOrder(col: Int) {
                 val alreadySorted = sortKeys.any {
                     it.column == col && it.sortOrder != SortOrder.UNSORTED
@@ -144,7 +144,7 @@ class TracepointTable(private val model: TracepointTableModel) : JBTable(model) 
     }
 
     override fun createDefaultTableHeader(): JTableHeader {
-        return object : JBTableHeader() {
+        return object: JBTableHeader() {
             init {
                 // Override the renderer that JBTableHeader sets.
                 // The default, center-aligned renderer looks better.

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -89,10 +89,16 @@ object TracerConfig {
         lock.withLock {
             val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
             val methodSignature = "$methodName$methodDesc"
-            val tracepoint = createTracepoint(
-                classJvmName, methodName, methodDesc, TracepointProperties.DEFAULT
-            )
-            classConfig.methodIds.getOrPut(methodSignature) { tracepoints.append(tracepoint) }
+            val methodId = classConfig.methodIds.getOrPut(methodSignature) {
+                val tracepoint = createTracepoint(
+                    classJvmName, methodName, methodDesc, TracepointProperties.DEFAULT
+                )
+                tracepoints.append(tracepoint)
+            }
+
+            val tracepoint = getTracepoint(methodId)
+            tracepoint.parameters.set(0)
+            tracepoint.setFlags(TracepointFlags.TRACE_ALL)
         }
     }
 

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerMethodTransformer.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerMethodTransformer.kt
@@ -42,7 +42,7 @@ import kotlin.reflect.jvm.javaMethod
 // - Stress-test this transformer by running it on a lot of classes.
 
 /** Inserts calls (within JVM byte code) to the trampoline. */
-class TracerMethodTransformer : ClassFileTransformer {
+class TracerMethodTransformer: ClassFileTransformer {
 
     companion object {
         private val LOG = Logger.getInstance(TracerMethodTransformer::class.java)
@@ -66,7 +66,8 @@ class TracerMethodTransformer : ClassFileTransformer {
         return try {
             if (!TracerConfig.shouldInstrumentClass(className)) return null
             tryTransform(className, classfileBuffer)
-        } catch (e: Throwable) {
+        }
+        catch (e: Throwable) {
             LOG.error("Failed to instrument class $className", e)
             throw e
         }
@@ -79,7 +80,7 @@ class TracerMethodTransformer : ClassFileTransformer {
         val reader = ClassReader(classBytes)
         val writer = ClassWriter(reader, COMPUTE_MAXS or COMPUTE_FRAMES)
 
-        val classVisitor = object : ClassVisitor(ASM_API, writer) {
+        val classVisitor = object: ClassVisitor(ASM_API, writer) {
 
             override fun visitMethod(
                 access: Int,
@@ -99,7 +100,7 @@ class TracerMethodTransformer : ClassFileTransformer {
                     return methodWriter
                 }
 
-                return object : AdviceAdapter(ASM_API, methodWriter, access, method, desc) {
+                return object: AdviceAdapter(ASM_API, methodWriter, access, method, desc) {
                     val methodStart = Label()
                     val methodEnd = Label()
 

--- a/src/main/java/com/google/idea/perf/util/ConcurrentAppendOnlyList.kt
+++ b/src/main/java/com/google/idea/perf/util/ConcurrentAppendOnlyList.kt
@@ -24,7 +24,7 @@ package com.google.idea.perf.util
  * Calls to [get] are O(1) and lock-free.
  * Calls to [append] are amortized O(1) but require locking.
  */
-class ConcurrentAppendOnlyList<T : Any>(initialCapacity: Int = 0) {
+class ConcurrentAppendOnlyList<T: Any>(initialCapacity: Int = 0) {
 
     @Volatile
     private var data = arrayOfNulls<Any?>(initialCapacity)

--- a/src/main/java/com/google/idea/perf/util/Matching.kt
+++ b/src/main/java/com/google/idea/perf/util/Matching.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf
+package com.google.idea.perf.util
 
 import com.intellij.util.containers.SLRUMap
 

--- a/src/test/java/com/google/idea/perf/methodtracer/AgentLoaderTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/AgentLoaderTest.kt
@@ -17,10 +17,9 @@
 package com.google.idea.perf.methodtracer
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import com.intellij.util.SystemProperties
 import org.junit.Test
 
-class AgentLoaderTest : BasePlatformTestCase() {
+class AgentLoaderTest: BasePlatformTestCase() {
 
     @Test
     fun testLoadAgent() {

--- a/src/test/java/com/google/idea/perf/methodtracer/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/CallTreeTest.kt
@@ -29,7 +29,7 @@ class CallTreeTest {
         maxWallTime: Long,
         override val argSetStats: Map<ArgSet, Stats> = emptyMap(),
         childrenList: List<Tree> = emptyList()
-    ) : CallTree {
+    ): CallTree {
 
         override val stats = Stats(callCount, wallTime, maxWallTime)
         override val children = childrenList.associateBy { it.tracepoint }
@@ -44,7 +44,7 @@ class CallTreeTest {
     private fun newArgSet(vararg values: Any?): ArgSet =
         ArgSet(values.mapIndexed { i, value -> Argument(value, i.toByte()) }.toTypedArray())
 
-    class TestClock : CallTreeBuilder.Clock {
+    class TestClock: CallTreeBuilder.Clock {
         var time = 0L
         override fun sample(): Long = time
     }

--- a/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
@@ -36,7 +36,7 @@ class MethodTracerCommandTest {
         assertCommand(MethodTracerCommand.Clear, "  clear")
         assertCommand(MethodTracerCommand.Clear, "  clear  ")
 
-        // Untrace commands.
+        // Basic untrace commands.
         assertCommand(
             MethodTracerCommand.Trace(false, TraceOption.ALL, null),
             "untrace"
@@ -62,6 +62,26 @@ class MethodTracerCommandTest {
             MethodTracerCommand.Trace(false, TraceOption.CALL_COUNT, TraceTarget.Tracer),
             "untrace count tracer"
         )
+
+        // Wildcard untrace commands.
+        assertCommand(
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.All),
+            "untrace *"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.WildcardClass("Test")),
+            "untrace Test*"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "")),
+            "untrace Test#*"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "get")),
+            "untrace Test#get*"
+        )
+
+        // Method untrace commands.
         assertCommand(
             MethodTracerCommand.Trace(
                 false,
@@ -95,7 +115,7 @@ class MethodTracerCommandTest {
             "untrace all com.example.MyAction#actionPerformed[0,1]"
         )
 
-        // Trace commands.
+        // Basic trace commands.
         assertCommand(
             MethodTracerCommand.Trace(true, TraceOption.ALL, null),
             "trace"
@@ -104,7 +124,6 @@ class MethodTracerCommandTest {
             MethodTracerCommand.Trace(true, TraceOption.WALL_TIME, null),
             "trace wall-time"
         )
-
         assertCommand(
             MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.PsiFinders),
             "trace psi-finders"
@@ -121,6 +140,26 @@ class MethodTracerCommandTest {
             MethodTracerCommand.Trace(true, TraceOption.CALL_COUNT, TraceTarget.Tracer),
             "trace count tracer"
         )
+
+        // Wildcard trace commands.
+        assertCommand(
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.All),
+            "trace *"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.WildcardClass("Test")),
+            "trace Test*"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "")),
+            "trace Test#*"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "get")),
+            "trace Test#get*"
+        )
+
+        // Method trace commands.
         assertCommand(
             MethodTracerCommand.Trace(
                 true,

--- a/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
@@ -19,7 +19,7 @@ package com.google.idea.perf.methodtracer
 import org.junit.Test
 import kotlin.test.assertEquals
 
-private fun assertCommand(expected: MethodTracerCommand?, actual: String) {
+private fun assertCommand(expected: MethodTracerCommand, actual: String) {
     assertEquals(expected, parseMethodTracerCommand(actual))
 }
 
@@ -27,7 +27,7 @@ class MethodTracerCommandTest {
     @Test
     fun testCommandParser() {
         // Basic commands.
-        assertCommand(null, "nonexistent-command")
+        assertCommand(MethodTracerCommand.Unknown, "unknown-command")
         assertCommand(MethodTracerCommand.Clear, "clear")
         assertCommand(MethodTracerCommand.Reset, "reset")
 

--- a/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
@@ -172,7 +172,7 @@ class MethodTracerCommandTest {
             MethodTracerCommand.Trace(
                 true,
                 TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", null, null)
+                TraceTarget.Method("com.example.MyAction", "", null)
             ),
             "trace com.example.MyAction#"
         )
@@ -196,7 +196,7 @@ class MethodTracerCommandTest {
             MethodTracerCommand.Trace(
                 true,
                 TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", null, null)
+                TraceTarget.Method("com.example.MyAction", "", null)
             ),
             "trace all com.example.MyAction#"
         )

--- a/src/test/java/com/google/idea/perf/util/MatchingBenchmark.kt
+++ b/src/test/java/com/google/idea/perf/util/MatchingBenchmark.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf
+package com.google.idea.perf.util
 
 import java.nio.file.Files
 import java.nio.file.Paths

--- a/src/test/java/com/google/idea/perf/util/MatchingTest.kt
+++ b/src/test/java/com/google/idea/perf/util/MatchingTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf
+package com.google.idea.perf.util
 
 import org.junit.Test
 import kotlin.test.assertNotNull


### PR DESCRIPTION
# Description

This pull request includes various improvements, bug fixes, and refactorings.

# Changes

- Improve startup time of tracer views by loading autocomplete classes on a separate thead
- Reload autocomplete classes periodically to discover new classes that are lazily loaded
- Bring back partial tracing (e.g. `trace count MyClass#myMethod`)
- Add proper tokenizer in method tracer parser, allowing for more lenient command syntax. See commit message for more details.
- Wildcard syntax. See commit message for more details.
- `untrace *` to untrace everything, including tracers, PSI finders, and traced methods.
- Notify the user when they run an invalid command or when the command fails.

# Bug Fixes

To see reproduction steps, refer to the commit message descriptions.

- Fix `trace tracer` not working after `untrace tracer`
- Fix autocomplete exceptions on incomplete commands (#20)
- Fix `trace all <ctrl+space>` not showing autocomplete