### PR TITLE
Add wildcard tracing

### DIFF
--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -18,14 +18,23 @@ package com.google.idea.perf.methodtracer
 
 import com.google.idea.perf.agent.MethodListener
 import com.google.idea.perf.util.ConcurrentAppendOnlyList
+import com.intellij.util.PatternUtil
 import org.objectweb.asm.Type
 import java.lang.reflect.Method
 import java.util.concurrent.locks.ReentrantLock
+import java.util.regex.Pattern
 import kotlin.concurrent.withLock
 
 // Things to improve:
 // - Somehow gc or recycle Tracepoints that are no longer used.
 // - Pretty-print method descriptors for better UX.
+
+sealed class TracePattern {
+    data class Exact(val method: Method): TracePattern()
+    data class ByMethodName(val className: String, val methodName: String): TracePattern()
+    data class ByMethodPattern(val className: String, val methodPattern: String): TracePattern()
+    data class ByClassPattern(val classPattern: String): TracePattern()
+}
 
 /** Keeps track of which methods should be traced via bytecode instrumentation. */
 object TracerConfig {
@@ -44,19 +53,93 @@ object TracerConfig {
 
     /** Specifies which methods to instrument for a given class. */
     private class ClassConfig {
-        /** Set of simple method names to instrumental and their associated properties. */
-        val methodNames = mutableMapOf<String, TracepointProperties>()
+        /**
+         * List of trace commands to execute before the class config is fully loaded with method IDs.
+         * If this field is null, then method IDs within the class config have been fully loaded.
+         */
+        var commands: MutableList<Pair<Pattern, TracepointProperties>>? = mutableListOf()
 
         /** Map from method signature to method ID. */
-        val methodIds = mutableMapOf<String, Int>()
+        val methodIds = mutableMapOf<String, Int?>()
     }
 
-    fun traceMethods(
-        classJvmName: String,
-        methodName: String,
-        flags: Int,
-        parameters: Collection<Int>
-    ) {
+    fun trace(
+        pattern: TracePattern,
+        flags: Int = TracepointFlags.TRACE_ALL,
+        parameters: Collection<Int> = emptyList()
+    ): List<String> {
+        return when (pattern) {
+            is TracePattern.Exact -> setTrace(true, pattern.method, flags, parameters)
+            is TracePattern.ByMethodName -> setTrace(true, pattern.className, pattern.methodName, flags, parameters)
+            is TracePattern.ByMethodPattern -> setTrace(true, pattern.className, pattern.methodPattern, flags, parameters)
+            is TracePattern.ByClassPattern -> setTrace(true, pattern.classPattern, flags, parameters)
+        }
+    }
+
+    fun untrace(pattern: TracePattern): List<String> {
+        return when(pattern) {
+            is TracePattern.Exact -> setTrace(false, pattern.method)
+            is TracePattern.ByMethodName -> setTrace(false, pattern.className, pattern.methodName)
+            is TracePattern.ByMethodPattern -> setTrace(false, pattern.className, pattern.methodPattern)
+            is TracePattern.ByClassPattern -> setTrace(false, pattern.classPattern)
+        }
+    }
+
+    private fun setTrace(
+        enable: Boolean,
+        method: Method,
+        flags: Int = 0,
+        parameters: Collection<Int> = emptyList()
+    ): List<String> {
+        val className = method.declaringClass.name
+        val classJvmName = className.replace('.', '/')
+        var parameterBits = 0
+        for (index in parameters) {
+            parameterBits = parameterBits or (1 shl index)
+        }
+
+        val methodDesc = Type.getMethodDescriptor(method)
+        val methodSignature = "${method.name}$methodDesc"
+
+        lock.withLock {
+            val methodId = if (flags and TracepointFlags.TRACE_ALL == 0) {
+                getMethodId(classJvmName, method.name, methodDesc)
+            }
+            else {
+                val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
+                classConfig.methodIds.getOrPut(methodSignature) {
+                    val tracepoint = createTracepoint(
+                        classJvmName, method.name, methodDesc, TracepointProperties.DEFAULT
+                    )
+                    tracepoints.append(tracepoint)
+                }
+            }
+
+            if (methodId != null) {
+                val tracepoint = getTracepoint(methodId)
+                tracepoint.parameters.set(parameterBits)
+
+                if (enable) {
+                    tracepoint.setFlags(flags)
+                }
+                else {
+                    tracepoint.unsetFlags(flags)
+                }
+            }
+
+            return listOf(className)
+        }
+    }
+
+    private fun setTrace(
+        enable: Boolean,
+        className: String,
+        methodPattern: String,
+        flags: Int = 0,
+        parameters: Collection<Int> = emptyList()
+    ): List<String> {
+        val classJvmName = className.replace('.', '/')
+        val methodRegex = Pattern.compile(PatternUtil.convertToRegex(methodPattern))
         var parameterBits = 0
         for (index in parameters) {
             parameterBits = parameterBits or (1 shl index)
@@ -64,83 +147,67 @@ object TracerConfig {
 
         lock.withLock {
             val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
-            classConfig.methodNames[methodName] = TracepointProperties(flags, parameterBits)
 
-            // If the tracepoint already exists, set tracepoint properties.
+            // If the class config isn't loaded, enqueue a command.
+            classConfig.commands?.add(Pair(methodRegex, TracepointProperties(flags, parameterBits)))
+
+            // If the class config is loaded, set tracepoint properties.
             for ((signature, methodId) in classConfig.methodIds) {
-                if (signature.substringBefore('(') == methodName) {
-                    val tracepoint = getTracepoint(methodId)
-                    tracepoint.setFlags(TracepointFlags.TRACE_ALL)
-                    tracepoint.parameters.set(parameterBits)
-                }
-            }
-        }
-    }
+                if (methodId != null) {
+                    val methodName = signature.substringBefore('(')
 
-    fun traceMethod(method: Method) {
-        lock.withLock {
-            val classJvmName = method.declaringClass.name.replace('.', '/')
-            val methodDesc = Type.getMethodDescriptor(method)
-            traceMethod(classJvmName, method.name, methodDesc)
-        }
-    }
-
-    private fun traceMethod(classJvmName: String, methodName: String, methodDesc: String) {
-        lock.withLock {
-            val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
-            val methodSignature = "$methodName$methodDesc"
-            val methodId = classConfig.methodIds.getOrPut(methodSignature) {
-                val tracepoint = createTracepoint(
-                    classJvmName, methodName, methodDesc, TracepointProperties.DEFAULT
-                )
-                tracepoints.append(tracepoint)
-            }
-
-            val tracepoint = getTracepoint(methodId)
-            tracepoint.parameters.set(0)
-            tracepoint.setFlags(TracepointFlags.TRACE_ALL)
-        }
-    }
-
-    fun untraceMethods(classJvmName: String, methodName: String) {
-        lock.withLock {
-            val classConfig = classConfigs[classJvmName] ?: return
-
-            for ((signature, _) in classConfig.methodIds) {
-                if (signature.substringBefore('(') == methodName) {
-                    val methodDesc = signature.substring(methodName.length)
-                    val methodId = getMethodId(classJvmName, methodName, methodDesc)
-                    if (methodId != null) {
+                    if (methodRegex.matcher(methodName).matches()) {
                         val tracepoint = getTracepoint(methodId)
-                        tracepoint.unsetFlags(TracepointFlags.TRACE_ALL)
-                        tracepoint.parameters.set(0)
+                        tracepoint.parameters.set(parameterBits)
+                        if (enable) {
+                            tracepoint.setFlags(flags)
+                        }
+                        else {
+                            tracepoint.unsetFlags(TracepointFlags.TRACE_ALL)
+                        }
                     }
                 }
             }
+
+            return listOf(className)
         }
     }
 
-    fun untraceMethod(method: Method) {
-        lock.withLock {
-            val classJvmName = method.declaringClass.name.replace('.', '/')
-            val methodDesc = Type.getMethodDescriptor(method)
-            untraceMethod(classJvmName, method.name, methodDesc)
-        }
-    }
+    private fun setTrace(
+        enable: Boolean,
+        classPattern: String,
+        flags: Int = 0,
+        parameters: Collection<Int> = emptyList()
+    ): List<String> {
+        val classes = AgentLoader.instrumentation?.allLoadedClasses
 
-    private fun untraceMethod(classJvmName: String, methodName: String, methodDesc: String) {
-        lock.withLock {
-            val methodId = getMethodId(classJvmName, methodName, methodDesc)
-            if (methodId != null) {
-                val tracepoint = getTracepoint(methodId)
-                tracepoint.unsetFlags(TracepointFlags.TRACE_ALL)
-                tracepoint.parameters.set(0)
+        if (classes != null) {
+            val regex = Pattern.compile(PatternUtil.convertToRegex(classPattern))
+            val matcher = regex.matcher("")
+            val matchingClasses = mutableListOf<String>()
+
+            for (clazz in classes) {
+                val className = clazz.name
+                matcher.reset(className)
+                if (matcher.matches()) {
+                    matchingClasses.add(className)
+                }
             }
+
+            lock.withLock {
+                for (className in matchingClasses) {
+                    setTrace(enable, className, "*", flags, parameters)
+                }
+            }
+
+            return matchingClasses
         }
+
+        return emptyList()
     }
 
     /** Remove all tracing and return the affected class names. */
-    fun removeAllTracing(): List<String> {
+    fun untraceAll(): List<String> {
         lock.withLock {
             val classNames = classConfigs.keys.map { it.replace('/', '.') }
             classConfigs.clear()
@@ -151,7 +218,33 @@ object TracerConfig {
     fun shouldInstrumentClass(classJvmName: String): Boolean {
         lock.withLock {
             val classConfig = classConfigs[classJvmName] ?: return false
-            return classConfig.methodNames.isNotEmpty() || classConfig.methodIds.isNotEmpty()
+            return classConfig.commands?.isNotEmpty() ?: true || classConfig.methodIds.isNotEmpty()
+        }
+    }
+
+    fun applyCommands(classJvmName: String, methodSignatures: Collection<String>) {
+        lock.withLock {
+            val classConfig = classConfigs[classJvmName] ?: return
+            val commands = classConfig.commands
+
+            if (commands != null) {
+                for (signature in methodSignatures) {
+                    classConfig.methodIds.putIfAbsent(signature, null)
+                }
+
+                for ((pattern, properties) in commands) {
+                    for (signature in methodSignatures) {
+                        if (pattern.matcher(signature).matches()) {
+                            val index = signature.indexOf('(')
+                            val methodName = signature.substring(0, index)
+                            val methodDesc = signature.substring(index)
+                            putMethodId(classJvmName, methodName, methodDesc, properties)
+                        }
+                    }
+                }
+
+                classConfig.commands = null
+            }
         }
     }
 
@@ -163,21 +256,28 @@ object TracerConfig {
         lock.withLock {
             val classConfig = classConfigs[classJvmName] ?: return null
             val methodSignature = "$methodName$methodDesc"
+            return classConfig.methodIds[methodSignature]
+        }
+    }
 
+    private fun putMethodId(
+        classJvmName: String, methodName: String, methodDesc: String,
+        properties: TracepointProperties
+    ): Int? {
+        lock.withLock {
+            val classConfig = classConfigs[classJvmName] ?: return null
+            val methodSignature = "$methodName$methodDesc"
             val existingId = classConfig.methodIds[methodSignature]
             if (existingId != null) {
+                getTracepoint(existingId).flags.set(properties.flags)
+                getTracepoint(existingId).parameters.set(properties.parameters)
                 return existingId
             }
 
-            val properties = classConfig.methodNames[methodName]
-            if (properties != null) {
-                val tracepoint = createTracepoint(classJvmName, methodName, methodDesc, properties)
-                val newId = tracepoints.append(tracepoint)
-                classConfig.methodIds[methodSignature] = newId
-                return newId
-            }
-
-            return null
+            val tracepoint = createTracepoint(classJvmName, methodName, methodDesc, properties)
+            val newId = tracepoints.append(tracepoint)
+            classConfig.methodIds[methodSignature] = newId
+            return newId
         }
     }
 

--- a/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
@@ -69,15 +69,15 @@ class MethodTracerCommandTest {
             "untrace *"
         )
         assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.WildcardClass("Test")),
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.ClassPattern("Test*")),
             "untrace Test*"
         )
         assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "")),
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*")),
             "untrace Test#*"
         )
         assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "get")),
+            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.MethodPattern("Test", "get*")),
             "untrace Test#get*"
         )
 
@@ -147,15 +147,23 @@ class MethodTracerCommandTest {
             "trace *"
         )
         assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.WildcardClass("Test")),
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.ClassPattern("*Test")),
+            "trace *Test"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.ClassPattern("Test*")),
             "trace Test*"
         )
         assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "")),
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*")),
             "trace Test#*"
         )
         assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.WildcardMethod("Test", "get")),
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*Value")),
+            "trace Test#*Value"
+        )
+        assertCommand(
+            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "get*")),
             "trace Test#get*"
         )
 

--- a/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/MethodTracerCommandTest.kt
@@ -19,6 +19,11 @@ package com.google.idea.perf.methodtracer
 import org.junit.Test
 import kotlin.test.assertEquals
 
+private typealias Unknown = MethodTracerCommand.Unknown
+private typealias Clear = MethodTracerCommand.Clear
+private typealias Reset = MethodTracerCommand.Reset
+private typealias Trace = MethodTracerCommand.Trace
+
 private fun assertCommand(expected: MethodTracerCommand, actual: String) {
     assertEquals(expected, parseMethodTracerCommand(actual))
 }
@@ -27,71 +32,37 @@ class MethodTracerCommandTest {
     @Test
     fun testCommandParser() {
         // Basic commands.
-        assertCommand(MethodTracerCommand.Unknown, "unknown-command")
-        assertCommand(MethodTracerCommand.Clear, "clear")
-        assertCommand(MethodTracerCommand.Reset, "reset")
+        assertCommand(Unknown, "unknown-command")
+        assertCommand(Clear, "clear")
+        assertCommand(Reset, "reset")
 
         // Corner case: Leading and trailing whitespace.
-        assertCommand(MethodTracerCommand.Clear, "clear  ")
-        assertCommand(MethodTracerCommand.Clear, "  clear")
-        assertCommand(MethodTracerCommand.Clear, "  clear  ")
+        assertCommand(Clear, "clear  ")
+        assertCommand(Clear, "  clear")
+        assertCommand(Clear, "  clear  ")
 
         // Basic untrace commands.
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, null),
-            "untrace"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.WALL_TIME, null),
-            "untrace wall-time"
-        )
+        assertCommand(Trace(false, TraceOption.ALL, null), "untrace")
+        assertCommand(Trace(false, TraceOption.WALL_TIME, null), "untrace wall-time")
 
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.PsiFinders),
-            "untrace psi-finders"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.PsiFinders),
-            "untrace all psi-finders"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.Tracer),
-            "untrace tracer"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.CALL_COUNT, TraceTarget.Tracer),
-            "untrace count tracer"
-        )
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.PsiFinders), "untrace psi-finders")
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.PsiFinders), "untrace all psi-finders")
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.Tracer), "untrace tracer")
+        assertCommand(Trace(false, TraceOption.CALL_COUNT, TraceTarget.Tracer), "untrace count tracer")
 
         // Wildcard untrace commands.
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.All),
-            "untrace *"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.ClassPattern("Test*")),
-            "untrace Test*"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*")),
-            "untrace Test#*"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(false, TraceOption.ALL, TraceTarget.MethodPattern("Test", "get*")),
-            "untrace Test#get*"
-        )
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.All), "untrace *")
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.ClassPattern("Test*")), "untrace Test*")
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*")), "untrace Test#*")
+        assertCommand(Trace(false, TraceOption.ALL, TraceTarget.MethodPattern("Test", "get*")), "untrace Test#get*")
 
         // Method untrace commands.
         assertCommand(
-            MethodTracerCommand.Trace(
-                false,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())
-            ),
+            Trace(false, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())),
             "untrace com.example.MyAction#actionPerformed"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
+            Trace(
                 false,
                 TraceOption.WALL_TIME,
                 TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())
@@ -99,201 +70,93 @@ class MethodTracerCommandTest {
             "untrace wall-time com.example.MyAction#actionPerformed"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                false,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0))
-            ),
+            Trace(false, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0))),
             "untrace all com.example.MyAction#actionPerformed[0]"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                false,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))
-            ),
+            Trace(false, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))),
             "untrace all com.example.MyAction#actionPerformed[0,1]"
         )
 
         // Basic trace commands.
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, null),
-            "trace"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.WALL_TIME, null),
-            "trace wall-time"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.PsiFinders),
-            "trace psi-finders"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.WALL_TIME, TraceTarget.PsiFinders),
-            "trace wall-time psi-finders"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.Tracer),
-            "trace tracer"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.CALL_COUNT, TraceTarget.Tracer),
-            "trace count tracer"
-        )
+        assertCommand(Trace(true, TraceOption.ALL, null), "trace")
+        assertCommand(Trace(true, TraceOption.WALL_TIME, null), "trace wall-time")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.PsiFinders), "trace psi-finders")
+        assertCommand(Trace(true, TraceOption.WALL_TIME, TraceTarget.PsiFinders), "trace wall-time psi-finders")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.Tracer), "trace tracer")
+        assertCommand(Trace(true, TraceOption.CALL_COUNT, TraceTarget.Tracer), "trace count tracer")
 
         // Wildcard trace commands.
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.All),
-            "trace *"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.ClassPattern("*Test")),
-            "trace *Test"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.ClassPattern("Test*")),
-            "trace Test*"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*")),
-            "trace Test#*"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*Value")),
-            "trace Test#*Value"
-        )
-        assertCommand(
-            MethodTracerCommand.Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "get*")),
-            "trace Test#get*"
-        )
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.All), "trace *")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.ClassPattern("*Test")), "trace *Test")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.ClassPattern("Test*")), "trace Test*")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*")), "trace Test#*")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "*Value")), "trace Test#*Value")
+        assertCommand(Trace(true, TraceOption.ALL, TraceTarget.MethodPattern("Test", "get*")), "trace Test#get*")
 
         // Method trace commands.
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", null, null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", null, null)),
             "trace com.example.MyAction"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "", null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "", null)),
             "trace com.example.MyAction#"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())),
             "trace com.example.MyAction#actionPerformed"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", null, null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", null, null)),
             "trace all com.example.MyAction"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "", null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "", null)),
             "trace all com.example.MyAction#"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", emptyList())),
             "trace all com.example.MyAction#actionPerformed"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", null)),
             "trace all com.example.MyAction#actionPerformed["
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", null)),
             "trace all com.example.MyAction#actionPerformed[0"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0))
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0))),
             "trace all com.example.MyAction#actionPerformed[0]"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", null)),
             "trace all com.example.MyAction#actionPerformed[0,"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", null)
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", null)),
             "trace all com.example.MyAction#actionPerformed[0,1"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))),
             "trace all com.example.MyAction#actionPerformed[0,1]"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))),
             "trace all com.example.MyAction#actionPerformed[0, 1]"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))),
             "trace all com.example.MyAction#actionPerformed[0 , 1]"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))),
             "trace all com.example.MyAction#actionPerformed[ 0,1 ]"
         )
         assertCommand(
-            MethodTracerCommand.Trace(
-                true,
-                TraceOption.ALL,
-                TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))
-            ),
+            Trace(true, TraceOption.ALL, TraceTarget.Method("com.example.MyAction", "actionPerformed", listOf(0, 1))),
             "trace all com.example.MyAction#actionPerformed [0,1]"
         )
     }


### PR DESCRIPTION
# Description

Wildcard tracing lets you trace all methods or classes that match a wildcard pattern. This will be useful for users performing broad-phase profiling to figure out where the bottlenecks are located.

# Command Syntax

```
[un]trace MyClass#*
[un]trace MyClass#get*
[un]trace MyClass#*Value
[un]trace *MyClass
[un]trace com.google.*
untrace *
```

# Todos

- [x] TracerConfig should load all method signatures and classes. This is one approach to make `untrace` work properly.
- [x] ~~Another approach: Linearly traverse through method patterns to make `untrace` work properly.~~ I decided to use the first approach because it is easier to reason about in the long term.
- [x] Wildcard tracing on classes
- [ ] Some exceptions are being thrown on with class wildcard tracing (could have already been an issue, but this feature uncovered this bug?)