### PR TITLE
Add VFS Tracer

### DIFF
--- a/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerHook.java
+++ b/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerHook.java
@@ -16,8 +16,6 @@
 
 package com.google.idea.perf.vfstracer;
 
-import java.util.Collection;
-
 public interface VfsTracerHook {
     void onPsiElementCreate(Object psiElement);
 

--- a/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerHook.java
+++ b/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerHook.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer;
+
+import java.util.Collection;
+
+public interface VfsTracerHook {
+    void onPsiElementCreate(Object psiElement);
+
+    Object onStubIndexProcessorCreate(Object processor);
+}

--- a/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerTrampoline.java
+++ b/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerTrampoline.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer;
+
+/**
+ * Hook methods that IntelliJ can call into as a link between IntelliJ's core class loaders and
+ * IDE Perf's plugin class loader.
+ */
+public final class VfsTracerTrampoline {
+    private static VfsTracerHook hook = new VfsTracerHookStub();
+
+    public static void installHook(VfsTracerHook newHook) {
+        hook = newHook;
+    }
+
+    public static void onPsiElementCreate(Object psiElement) {
+        hook.onPsiElementCreate(psiElement);
+    }
+
+    public static Object onStubIndexProcessorCreate(Object processor) {
+        return hook.onStubIndexProcessorCreate(processor);
+    }
+
+    private static class VfsTracerHookStub implements VfsTracerHook {
+        @Override
+        public void onPsiElementCreate(Object psiElement) {}
+
+        @Override
+        public Object onStubIndexProcessorCreate(Object processor) {
+            return processor;
+        }
+    }
+}

--- a/src/main/java/com/google/idea/perf/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/TracerController.kt
@@ -59,15 +59,21 @@ abstract class TracerController(
     abstract fun onControllerInitialize()
 
     protected fun dataRefreshLoop() {
-        val startTime = System.nanoTime()
+        try {
+            val startTime = System.nanoTime()
 
-        if (updateModel()) {
-            updateUi()
+            if (updateModel()) {
+                updateUi()
+            }
+
+            val endTime = System.nanoTime()
+            val elapsedNanos = endTime - startTime
+            updateRefreshTimeUi(elapsedNanos)
         }
-
-        val endTime = System.nanoTime()
-        val elapsedNanos = endTime - startTime
-        updateRefreshTimeUi(elapsedNanos)
+        catch (ex: Exception) {
+            LOG.error("Exception was caught while tracing", ex)
+            throw ex
+        }
     }
 
     protected abstract fun updateModel(): Boolean

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsStatTable.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsStatTable.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
+import java.awt.Font
+import javax.swing.ListSelectionModel
+import javax.swing.SortOrder
+import javax.swing.SwingConstants
+import javax.swing.table.AbstractTableModel
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.JTableHeader
+import javax.swing.table.TableRowSorter
+
+private const val COL_COUNT = 3
+
+// Table columns.
+private const val FILE_NAME = 0
+private const val STUB_INDEX_ACCESSES = 1
+private const val PSI_WRAPS = 2
+
+class VfsStatTableModel: AbstractTableModel() {
+    private var data: List<VirtualFileStats>? = null
+
+    fun setData(newData: List<VirtualFileStats>?) {
+        data = newData
+        fireTableDataChanged()
+    }
+
+    override fun getColumnCount(): Int = COL_COUNT
+
+    override fun getColumnName(column: Int): String = when (column) {
+        FILE_NAME -> "file name"
+        STUB_INDEX_ACCESSES -> "stub index accesses"
+        PSI_WRAPS -> "psi wraps"
+        else -> error(column)
+    }
+
+    override fun getColumnClass(columnIndex: Int): Class<*> = when (columnIndex) {
+        FILE_NAME -> java.lang.String::class.java
+        STUB_INDEX_ACCESSES, PSI_WRAPS -> java.lang.Integer::class.java
+        else -> error(columnIndex)
+    }
+
+    override fun getRowCount(): Int = data?.size ?: 0
+
+    override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+        val stats = data!![rowIndex]
+        return when (columnIndex) {
+            FILE_NAME -> stats.fileName
+            STUB_INDEX_ACCESSES -> stats.stubIndexAccesses
+            PSI_WRAPS -> stats.psiElementWraps
+            else -> error(columnIndex)
+        }
+    }
+
+    override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean = false
+}
+
+class VfsStatTable(private val model: VfsStatTableModel): JBTable(model) {
+    init {
+        font = JBUI.Fonts.create(Font.MONOSPACED, font.size)
+        setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+        setShowGrid(false)
+
+        // Column rendering.
+        val columnModel = columnModel
+        for (col in 0 until COL_COUNT) {
+            val tableColumn = columnModel.getColumn(col)
+
+            // Column widths.
+            tableColumn.minWidth = 100
+            tableColumn.preferredWidth = when (col) {
+                FILE_NAME -> Int.MAX_VALUE
+                STUB_INDEX_ACCESSES, PSI_WRAPS -> 100
+                else -> tableColumn.preferredWidth
+            }
+
+            // Locale-aware and unit-aware rendering for numbers.
+            when (col) {
+                STUB_INDEX_ACCESSES, PSI_WRAPS -> {
+                    tableColumn.cellRenderer = object: DefaultTableCellRenderer() {
+                        init {
+                            horizontalAlignment = SwingConstants.RIGHT
+                        }
+                    }
+                }
+            }
+        }
+
+        // Limit sorting directions.
+        rowSorter = object: TableRowSorter<VfsStatTableModel>(model) {
+            override fun toggleSortOrder(col: Int) {
+                val alreadySorted = sortKeys.any {
+                    it.column == col && it.sortOrder != SortOrder.UNSORTED
+                }
+                if (alreadySorted) return
+                val order = when (col) {
+                    FILE_NAME -> SortOrder.ASCENDING
+                    else -> SortOrder.DESCENDING
+                }
+                sortKeys = listOf(SortKey(col, order))
+            }
+        }
+        rowSorter.toggleSortOrder(PSI_WRAPS)
+    }
+
+    override fun createDefaultTableHeader(): JTableHeader {
+        return object: JBTableHeader() {
+            init {
+                defaultRenderer = createDefaultRenderer()
+            }
+        }
+    }
+
+    fun setStats(newStats: List<VirtualFileStats>?) {
+        val selection = selectionModel.leadSelectionIndex
+        model.setData(newStats)
+        if (selection != -1 && selection < model.rowCount) {
+            selectionModel.setSelectionInterval(selection, selection)
+        }
+    }
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsStatTable.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsStatTable.kt
@@ -47,7 +47,7 @@ class VfsStatTableModel: AbstractTableModel() {
     override fun getColumnName(column: Int): String = when (column) {
         FILE_NAME -> "file name"
         STUB_INDEX_ACCESSES -> "stub index accesses"
-        PSI_ELEMENT_WRAPS -> "psi wraps"
+        PSI_ELEMENT_WRAPS -> "psi parses"
         else -> error(column)
     }
 

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsStatTable.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsStatTable.kt
@@ -32,7 +32,7 @@ private const val COL_COUNT = 3
 // Table columns.
 private const val FILE_NAME = 0
 private const val STUB_INDEX_ACCESSES = 1
-private const val PSI_WRAPS = 2
+private const val PSI_ELEMENT_WRAPS = 2
 
 class VfsStatTableModel: AbstractTableModel() {
     private var data: List<VirtualFileStats>? = null
@@ -47,13 +47,13 @@ class VfsStatTableModel: AbstractTableModel() {
     override fun getColumnName(column: Int): String = when (column) {
         FILE_NAME -> "file name"
         STUB_INDEX_ACCESSES -> "stub index accesses"
-        PSI_WRAPS -> "psi wraps"
+        PSI_ELEMENT_WRAPS -> "psi wraps"
         else -> error(column)
     }
 
     override fun getColumnClass(columnIndex: Int): Class<*> = when (columnIndex) {
         FILE_NAME -> java.lang.String::class.java
-        STUB_INDEX_ACCESSES, PSI_WRAPS -> java.lang.Integer::class.java
+        STUB_INDEX_ACCESSES, PSI_ELEMENT_WRAPS -> java.lang.Integer::class.java
         else -> error(columnIndex)
     }
 
@@ -64,7 +64,7 @@ class VfsStatTableModel: AbstractTableModel() {
         return when (columnIndex) {
             FILE_NAME -> stats.fileName
             STUB_INDEX_ACCESSES -> stats.stubIndexAccesses
-            PSI_WRAPS -> stats.psiElementWraps
+            PSI_ELEMENT_WRAPS -> stats.psiElementWraps
             else -> error(columnIndex)
         }
     }
@@ -87,13 +87,13 @@ class VfsStatTable(private val model: VfsStatTableModel): JBTable(model) {
             tableColumn.minWidth = 100
             tableColumn.preferredWidth = when (col) {
                 FILE_NAME -> Int.MAX_VALUE
-                STUB_INDEX_ACCESSES, PSI_WRAPS -> 100
+                STUB_INDEX_ACCESSES, PSI_ELEMENT_WRAPS -> 100
                 else -> tableColumn.preferredWidth
             }
 
             // Locale-aware and unit-aware rendering for numbers.
             when (col) {
-                STUB_INDEX_ACCESSES, PSI_WRAPS -> {
+                STUB_INDEX_ACCESSES, PSI_ELEMENT_WRAPS -> {
                     tableColumn.cellRenderer = object: DefaultTableCellRenderer() {
                         init {
                             horizontalAlignment = SwingConstants.RIGHT
@@ -117,7 +117,7 @@ class VfsStatTable(private val model: VfsStatTableModel): JBTable(model) {
                 sortKeys = listOf(SortKey(col, order))
             }
         }
-        rowSorter.toggleSortOrder(PSI_WRAPS)
+        rowSorter.toggleSortOrder(STUB_INDEX_ACCESSES)
     }
 
     override fun createDefaultTableHeader(): JTableHeader {

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsStatTreeTable.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsStatTreeTable.kt
@@ -26,7 +26,7 @@ import javax.swing.tree.TreePath
 
 private const val COLUMN_COUNT = 2
 private const val STUB_INDEX_ACCESSES = 0
-private const val PSI_WRAPS = 1
+private const val PSI_ELEMENT_WRAPS = 1
 
 private operator fun VirtualFileTree.get(index: Int): VirtualFileTree =
     children.values.toTypedArray()[index]
@@ -54,7 +54,7 @@ class VfsStatTreeTableModel: TreeTableModel {
                 forEachListener { it.treeStructureChanged(event) }
             }
 
-            override fun onTreeChange(
+            override fun onTreeModify(
                 path: VirtualFileTreePath,
                 parent: MutableVirtualFileTree,
                 child: MutableVirtualFileTree,
@@ -97,12 +97,12 @@ class VfsStatTreeTableModel: TreeTableModel {
 
     override fun getColumnName(column: Int): String = when (column) {
         STUB_INDEX_ACCESSES -> "stub index accesses"
-        PSI_WRAPS -> "psi wraps"
+        PSI_ELEMENT_WRAPS -> "psi wraps"
         else -> error(column)
     }
 
     override fun getColumnClass(column: Int): Class<*> = when (column) {
-        STUB_INDEX_ACCESSES, PSI_WRAPS -> java.lang.Integer::class.java
+        STUB_INDEX_ACCESSES, PSI_ELEMENT_WRAPS -> java.lang.Integer::class.java
         else -> error(column)
     }
 
@@ -110,7 +110,7 @@ class VfsStatTreeTableModel: TreeTableModel {
         node as VirtualFileTree
         return when (column) {
             STUB_INDEX_ACCESSES -> node.stubIndexAccesses
-            PSI_WRAPS -> node.psiElementWraps
+            PSI_ELEMENT_WRAPS -> node.psiElementWraps
             else -> error(column)
         }
     }

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsStatTreeTable.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsStatTreeTable.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import com.intellij.ui.components.JBTreeTable
+import com.intellij.ui.treeStructure.treetable.TreeTableModel
+import javax.swing.JTree
+import javax.swing.event.EventListenerList
+import javax.swing.event.TreeModelEvent
+import javax.swing.event.TreeModelListener
+import javax.swing.tree.TreePath
+
+private const val COLUMN_COUNT = 2
+private const val STUB_INDEX_ACCESSES = 0
+private const val PSI_WRAPS = 1
+
+private operator fun VirtualFileTree.get(index: Int): VirtualFileTree =
+    children.values.toTypedArray()[index]
+
+private fun VirtualFileTree.indexOf(child: VirtualFileTree): Int =
+    children.values.indexOfFirst { it.name == child.name }
+
+class VfsStatTreeTableModel: TreeTableModel {
+    private val tree = MutableVirtualFileTree.createRoot()
+    private val listeners = EventListenerList()
+
+    fun setStats(newStats: VirtualFileTree) {
+        val treeDiff = VirtualFileTreeDiff.create(tree, newStats)
+        val listenerList = listeners.listenerList
+
+        treeDiff.applyPatch(object: TreePatchEventListener {
+            override fun onTreeInsert(
+                path: VirtualFileTreePath,
+                parent: MutableVirtualFileTree,
+                child: MutableVirtualFileTree
+            ) {
+                parent.children[child.name] = child
+                val treePath = TreePath(path.parts)
+                val event = TreeModelEvent(this, treePath)
+                forEachListener { it.treeStructureChanged(event) }
+            }
+
+            override fun onTreeChange(
+                path: VirtualFileTreePath,
+                parent: MutableVirtualFileTree,
+                child: MutableVirtualFileTree,
+                newChild: VirtualFileTree
+            ) {
+                child.stubIndexAccesses = newChild.stubIndexAccesses
+                child.psiElementWraps = newChild.psiElementWraps
+
+                val treePath = TreePath(path.parts)
+                val indexes = intArrayOf(parent.indexOf(child))
+                val children = arrayOf(child)
+                val event = TreeModelEvent(this, treePath, indexes, children)
+                forEachListener { it.treeNodesChanged(event) }
+            }
+
+            override fun onTreeRemove(
+                path: VirtualFileTreePath,
+                parent: MutableVirtualFileTree,
+                child: MutableVirtualFileTree
+            ) {
+                val treePath = TreePath(path.parts)
+                val indexes = intArrayOf(parent.indexOf(child))
+                val children = arrayOf(child)
+                val event = TreeModelEvent(this, treePath, indexes, children)
+                parent.children.remove(child.name)
+                forEachListener { it.treeNodesRemoved(event) }
+            }
+
+            private fun forEachListener(action: (TreeModelListener) -> Unit) {
+                for (i in listenerList.size - 2 downTo 0 step 2) {
+                    if (listenerList[i] == TreeModelListener::class.java) {
+                        action(listenerList[i + 1] as TreeModelListener)
+                    }
+                }
+            }
+        })
+    }
+
+    override fun getColumnCount(): Int = COLUMN_COUNT
+
+    override fun getColumnName(column: Int): String = when (column) {
+        STUB_INDEX_ACCESSES -> "stub index accesses"
+        PSI_WRAPS -> "psi wraps"
+        else -> error(column)
+    }
+
+    override fun getColumnClass(column: Int): Class<*> = when (column) {
+        STUB_INDEX_ACCESSES, PSI_WRAPS -> java.lang.Integer::class.java
+        else -> error(column)
+    }
+
+    override fun getValueAt(node: Any?, column: Int): Any {
+        node as VirtualFileTree
+        return when (column) {
+            STUB_INDEX_ACCESSES -> node.stubIndexAccesses
+            PSI_WRAPS -> node.psiElementWraps
+            else -> error(column)
+        }
+    }
+
+    override fun isCellEditable(node: Any?, column: Int): Boolean = false
+    override fun setValueAt(aValue: Any?, node: Any?, column: Int) = error("Model is not editable")
+    override fun setTree(tree: JTree?) {}
+
+    override fun getRoot(): Any = tree
+
+    override fun getChild(parent: Any?, index: Int): Any {
+        parent as VirtualFileTree
+        return parent[index]
+    }
+
+    override fun getChildCount(parent: Any?): Int {
+        parent as VirtualFileTree
+        return parent.children.size
+    }
+
+    override fun isLeaf(node: Any?): Boolean {
+        node as VirtualFileTree
+        return node.isFile
+    }
+
+    override fun valueForPathChanged(path: TreePath?, newValue: Any?) {}
+
+    override fun getIndexOfChild(parent: Any?, child: Any?): Int {
+        if (parent == null || child == null) {
+            return -1
+        }
+        parent as VirtualFileTree
+        child as VirtualFileTree
+        return parent.indexOf(child)
+    }
+
+    override fun addTreeModelListener(l: TreeModelListener?) {
+        listeners.add(TreeModelListener::class.java, l)
+    }
+
+    override fun removeTreeModelListener(l: TreeModelListener?) {
+        listeners.remove(TreeModelListener::class.java, l)
+    }
+}
+
+class VfsStatTreeTable(private val model: VfsStatTreeTableModel): JBTreeTable(model) {
+    fun setStats(newStats: VirtualFileTree) {
+        model.setStats(newStats)
+    }
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsStatTreeTable.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsStatTreeTable.kt
@@ -97,7 +97,7 @@ class VfsStatTreeTableModel: TreeTableModel {
 
     override fun getColumnName(column: Int): String = when (column) {
         STUB_INDEX_ACCESSES -> "stub index accesses"
-        PSI_ELEMENT_WRAPS -> "psi wraps"
+        PSI_ELEMENT_WRAPS -> "psi parses"
         else -> error(column)
     }
 
@@ -107,7 +107,7 @@ class VfsStatTreeTableModel: TreeTableModel {
     }
 
     override fun getValueAt(node: Any?, column: Int): Any {
-        node as VirtualFileTree
+        check(node is VirtualFileTree)
         return when (column) {
             STUB_INDEX_ACCESSES -> node.stubIndexAccesses
             PSI_ELEMENT_WRAPS -> node.psiElementWraps
@@ -122,17 +122,17 @@ class VfsStatTreeTableModel: TreeTableModel {
     override fun getRoot(): Any = tree
 
     override fun getChild(parent: Any?, index: Int): Any {
-        parent as VirtualFileTree
+        check(parent is VirtualFileTree)
         return parent[index]
     }
 
     override fun getChildCount(parent: Any?): Int {
-        parent as VirtualFileTree
+        check(parent is VirtualFileTree)
         return parent.children.size
     }
 
     override fun isLeaf(node: Any?): Boolean {
-        node as VirtualFileTree
+        check(node is VirtualFileTree)
         return node.isFile
     }
 
@@ -142,8 +142,8 @@ class VfsStatTreeTableModel: TreeTableModel {
         if (parent == null || child == null) {
             return -1
         }
-        parent as VirtualFileTree
-        child as VirtualFileTree
+        check(parent is VirtualFileTree)
+        check(child is VirtualFileTree)
         return parent.indexOf(child)
     }
 

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
@@ -32,8 +32,7 @@ class VfsTracerController(
         parentDisposable.attachChild(this)
     }
 
-    override fun onControllerInitialize() {
-    }
+    override fun onControllerInitialize() {}
 
     override fun updateModel(): Boolean {
         collectedStats = VirtualFileTracer.collectAndReset()

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import com.google.idea.perf.TracerController
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager.getApplication
+import com.intellij.openapi.rd.attachChild
+
+class VfsTracerController(
+    private val view: VfsTracerView,
+    parentDisposable: Disposable
+): TracerController("VFS Tracer", view) {
+    private var accumulatedStats = MutableVirtualFileTree.createRoot()
+    private var collectedStats = VirtualFileTree.EMPTY
+
+    init {
+        parentDisposable.attachChild(this)
+    }
+
+    override fun onControllerInitialize() {
+    }
+
+    override fun updateModel(): Boolean {
+        collectedStats = VirtualFileTracer.collectAndReset()
+        return collectedStats.children.isNotEmpty()
+    }
+
+    override fun updateUi() {
+        accumulatedStats.accumulate(collectedStats)
+        val listStats = accumulatedStats.flattenedList()
+
+        getApplication().invokeAndWait {
+            view.listView.setStats(listStats)
+            view.treeView.setStats(accumulatedStats)
+        }
+    }
+
+    override fun handleRawCommandFromEdt(text: String) {
+        executor.execute { handleCommand(text.trim()) }
+    }
+
+    private fun handleCommand(command: String) {
+        when (command) {
+            "start" -> VirtualFileTracer.startVfsTracing()
+            "stop" -> VirtualFileTracer.stopVfsTracing()
+            "clear" -> {
+                accumulatedStats.clear()
+                updateUi()
+            }
+            "reset" -> {
+                accumulatedStats = MutableVirtualFileTree.createRoot()
+                updateUi()
+            }
+        }
+    }
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerView.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerView.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import com.google.idea.perf.TracerView
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.rd.attach
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTabbedPane
+import com.intellij.ui.components.JBTreeTable
+import com.intellij.util.textCompletion.DefaultTextCompletionValueDescriptor
+import com.intellij.util.textCompletion.TextFieldWithCompletion
+import com.intellij.util.textCompletion.ValuesCompletionProvider
+import com.intellij.util.ui.JBFont
+import com.intellij.util.ui.JBUI
+import java.awt.Dimension
+import javax.swing.Action
+import javax.swing.BoxLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+import javax.swing.border.Border
+
+class VfsTracerAction: DumbAwareAction() {
+    private var currentTracer: VfsTracerDialog? = null
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val tracer = currentTracer
+        if (tracer != null) {
+            check(!tracer.isDisposed)
+            tracer.toFront()
+        }
+        else {
+            val newTracer = VfsTracerDialog()
+            currentTracer = newTracer
+            newTracer.disposable.attach { currentTracer = null }
+            newTracer.show()
+        }
+    }
+}
+
+class VfsTracerDialog: DialogWrapper(null, null, false, IdeModalityType.IDE, false) {
+    init {
+        title = "VFS Tracer"
+        isModal = false
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent? = VfsTracerView(disposable)
+    override fun createContentPaneBorder(): Border? = null
+    override fun getDimensionServiceKey(): String = "com.google.idea.perf.vfstracer.VfsTracer"
+    override fun createActions(): Array<Action> = emptyArray()
+}
+
+class VfsTracerView(parentDisposable: Disposable): TracerView() {
+    private val controller = VfsTracerController(this, parentDisposable)
+    override val commandLine: TextFieldWithCompletion
+    override val progressBar: JProgressBar
+    override val refreshTimeLabel: JBLabel
+    private val tabs: JBTabbedPane
+    val listView = VfsStatTable(VfsStatTableModel())
+    val treeView = VfsStatTreeTable(VfsStatTreeTableModel())
+
+    init {
+        preferredSize = Dimension(500, 500)
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+
+        // Command line.
+        commandLine = TextFieldWithCompletion(
+            ProjectManager.getInstance().defaultProject,
+            ValuesCompletionProvider(
+                DefaultTextCompletionValueDescriptor.StringValueDescriptor(),
+                listOf("start", "stop", "clear", "reset")
+            ),
+            "",
+            false,
+            true,
+            true
+        ).apply {
+            maximumSize = Dimension(Integer.MAX_VALUE, minimumSize.height)
+            addDocumentListener(object: DocumentListener {
+                override fun beforeDocumentChange(event: DocumentEvent) {
+                    if (event.newFragment.contains('\n')) {
+                        controller.handleRawCommandFromEdt(text)
+                        ApplicationManager.getApplication().invokeLater {
+                            this@apply.text = ""
+                        }
+                    }
+                }
+            })
+        }
+        add(commandLine)
+
+        // Progress bar.
+        progressBar = JProgressBar().apply {
+            isVisible = false
+            maximumSize = Dimension(Integer.MAX_VALUE, minimumSize.height)
+        }
+        add(progressBar)
+
+        // Tabs.
+        tabs = JBTabbedPane()
+        tabs.tabLayoutPolicy = JBTabbedPane.SCROLL_TAB_LAYOUT
+        add(tabs)
+
+        // List view.
+        tabs.add("List View", JBScrollPane(listView))
+        tabs.add("Tree View", JBScrollPane(treeView))
+
+        // Render time label.
+        refreshTimeLabel = JBLabel().apply {
+            font = JBUI.Fonts.create(JBFont.MONOSPACED, font.size)
+        }
+        add(JPanel().apply {
+            maximumSize = Dimension(Integer.MAX_VALUE, minimumSize.height)
+            add(refreshTimeLabel)
+        })
+
+        // Start data trace collection.
+        controller.startDataRefreshLoop()
+    }
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileStats.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileStats.kt
@@ -18,12 +18,14 @@ package com.google.idea.perf.vfstracer
 
 import java.util.*
 
+/** A file containing VirtualFile statistics. */
 data class VirtualFileStats(
     val fileName: String,
     val stubIndexAccesses: Int,
     val psiElementWraps: Int
 )
 
+/** Extracts all files from a [VirtualFileTree] and creates flattened list of [VirtualFileStats]. */
 fun VirtualFileTree.flattenedList(): List<VirtualFileStats> {
     fun flattenImpl(
         tree: VirtualFileTree,

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileStats.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileStats.kt
@@ -41,7 +41,7 @@ fun VirtualFileTree.flattenedList(): List<VirtualFileStats> {
         }
         else {
             list.add(VirtualFileStats(
-                pathBuilder.toTypedArray().joinToString("/"),
+                pathBuilder.joinToString("/"),
                 tree.stubIndexAccesses,
                 tree.psiElementWraps
             ))

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileStats.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileStats.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import java.util.*
+
+data class VirtualFileStats(
+    val fileName: String,
+    val stubIndexAccesses: Int,
+    val psiElementWraps: Int
+)
+
+fun VirtualFileTree.flattenedList(): List<VirtualFileStats> {
+    fun flattenImpl(
+        tree: VirtualFileTree,
+        pathBuilder: Stack<String>,
+        list: MutableList<VirtualFileStats>
+    ) {
+        pathBuilder.push(tree.name)
+
+        if (tree.isDirectory) {
+            for (child in tree.children.values) {
+                flattenImpl(child, pathBuilder, list)
+            }
+        }
+        else {
+            list.add(VirtualFileStats(
+                pathBuilder.toTypedArray().joinToString("/"),
+                tree.stubIndexAccesses,
+                tree.psiElementWraps
+            ))
+        }
+
+        pathBuilder.pop()
+    }
+
+    val pathBuilder = Stack<String>()
+    val list = mutableListOf<VirtualFileStats>()
+    for (child in children.values) {
+        flattenImpl(child, pathBuilder, list)
+    }
+    return list
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTracer.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTracer.kt
@@ -46,7 +46,14 @@ private val LOG = Logger.getInstance(VirtualFileTracer::class.java)
 
 /** Records and manages VirtualFile statistics. */
 object VirtualFileTracer {
+    private var hooksInstalled = false
+
     fun startVfsTracing() {
+        if (hooksInstalled) {
+            VirtualFileTracerImpl.isEnabled = true
+            return
+        }
+
         val instrumentation = AgentLoader.instrumentation
         if (instrumentation == null) {
             LOG.error("Failed to get instrumentation instance.")
@@ -57,10 +64,12 @@ object VirtualFileTracer {
         val compositeElementClass = classes.firstOrNull { it.name == COMPOSITE_ELEMENT_CLASS }
         if (compositeElementClass == null) {
             LOG.error("Failed to get $compositeElementClass class.")
+            return
         }
         val stubIndexImplClass = classes.firstOrNull { it.name == STUB_INDEX_IMPL_CLASS }
         if (stubIndexImplClass == null) {
             LOG.error("Failed to get $stubIndexImplClass class.")
+            return
         }
 
         VirtualFileTracerImpl.isEnabled = true
@@ -70,6 +79,8 @@ object VirtualFileTracer {
         instrumentation.addTransformer(transformer, true)
         instrumentation.retransformClasses(compositeElementClass)
         instrumentation.retransformClasses(stubIndexImplClass)
+
+        hooksInstalled = true
     }
 
     fun stopVfsTracing() {

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTracer.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTracer.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import com.google.idea.perf.methodtracer.AgentLoader
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.psi.PsiElement
+import com.intellij.util.Processor
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassReader.SKIP_FRAMES
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.ClassWriter.COMPUTE_FRAMES
+import org.objectweb.asm.ClassWriter.COMPUTE_MAXS
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Opcodes.ASM8
+import org.objectweb.asm.Type
+import org.objectweb.asm.commons.AdviceAdapter
+import org.objectweb.asm.commons.Method
+import java.lang.instrument.ClassFileTransformer
+import java.security.ProtectionDomain
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.reflect.jvm.javaMethod
+
+private const val COMPOSITE_ELEMENT_CLASS = "com.intellij.psi.impl.source.tree.CompositeElement"
+private const val STUB_INDEX_IMPL_CLASS = "com.intellij.psi.stubs.StubIndexImpl"
+private val COMPOSITE_ELEMENT_JVM_CLASS = COMPOSITE_ELEMENT_CLASS.replace('.', '/')
+private val STUB_INDEX_IMPL_JVM_CLASS = STUB_INDEX_IMPL_CLASS.replace('.', '/')
+private val LOG = Logger.getInstance(VirtualFileTracer::class.java)
+
+/** Records and manages VirtualFile statistics. */
+object VirtualFileTracer {
+    fun startVfsTracing() {
+        val instrumentation = AgentLoader.instrumentation
+        if (instrumentation == null) {
+            LOG.error("Failed to get instrumentation instance.")
+            return
+        }
+
+        val classes = instrumentation.allLoadedClasses
+        val compositeElementClass = classes.firstOrNull { it.name == COMPOSITE_ELEMENT_CLASS }
+        if (compositeElementClass == null) {
+            LOG.error("Failed to get $compositeElementClass class.")
+        }
+        val stubIndexImplClass = classes.firstOrNull { it.name == STUB_INDEX_IMPL_CLASS }
+        if (stubIndexImplClass == null) {
+            LOG.error("Failed to get $stubIndexImplClass class.")
+        }
+
+        VirtualFileTracerImpl.isEnabled = true
+        VfsTracerTrampoline.installHook(VfsTracerHookImpl())
+
+        val transformer = TracerClassFileTransformer()
+        instrumentation.addTransformer(transformer, true)
+        instrumentation.retransformClasses(compositeElementClass)
+        instrumentation.retransformClasses(stubIndexImplClass)
+    }
+
+    fun stopVfsTracing() {
+        VirtualFileTracerImpl.isEnabled = false
+    }
+
+    /** Collect and reset the virtual file trees. */
+    fun collectAndReset(): VirtualFileTree = VirtualFileTracerImpl.collectAndReset()
+}
+
+private object VirtualFileTracerImpl {
+    @Volatile
+    var isEnabled: Boolean = false
+
+    var currentTree = MutableVirtualFileTree.createRoot()
+    val lock = ReentrantLock()
+
+    fun collectAndReset(): VirtualFileTree {
+        lock.withLock {
+            val tree = currentTree
+            currentTree = MutableVirtualFileTree.createRoot()
+            return tree
+        }
+    }
+
+    fun accumulateStats(fileName: String, stubIndexAccesses: Int = 0, psiElementWraps: Int = 0) {
+        lock.withLock {
+            currentTree.accumulate(fileName, stubIndexAccesses, psiElementWraps)
+        }
+    }
+}
+
+private class VfsTracerHookImpl: VfsTracerHook {
+    override fun onPsiElementCreate(psiElement: Any?) {
+        if (VirtualFileTracerImpl.isEnabled && psiElement is PsiElement) {
+            val fileName = getFileName(psiElement)
+            if (fileName != null) {
+                VirtualFileTracerImpl.accumulateStats(fileName, psiElementWraps = 1)
+            }
+        }
+    }
+
+    override fun onStubIndexProcessorCreate(processor: Any?): Any? {
+        if (!VirtualFileTracerImpl.isEnabled || processor == null) {
+            return processor
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        processor as Processor<PsiElement>
+
+        return Processor<PsiElement> {
+            val fileName = getFileName(it)
+            if (fileName != null) {
+                VirtualFileTracerImpl.accumulateStats(fileName, stubIndexAccesses = 1)
+            }
+            processor.process(it)
+        }
+    }
+
+    private fun getFileName(psiElement: PsiElement?): String? {
+        if (psiElement != null && psiElement.isValid) {
+            val file = psiElement.containingFile
+            val virtualFile = file.virtualFile
+            return virtualFile?.canonicalPath
+        }
+        return null
+    }
+}
+
+private class TracerClassFileTransformer: ClassFileTransformer {
+    companion object {
+        val HOOK_CLASS_JVM_NAME: String = Type.getInternalName(VfsTracerTrampoline::class.java)
+        val ON_PSI_ELEMENT_CREATE: Method = Method.getMethod(VfsTracerTrampoline::onPsiElementCreate.javaMethod)
+        val ON_STUB_INDEX_PROCESSOR_CREATE: Method = Method.getMethod(VfsTracerTrampoline::onStubIndexProcessorCreate.javaMethod)
+        const val ASM_API = ASM8
+    }
+
+    override fun transform(
+        loader: ClassLoader?,
+        className: String,
+        classBeingRedefined: Class<*>?,
+        protectionDomain: ProtectionDomain?,
+        classfileBuffer: ByteArray
+    ): ByteArray? {
+        try {
+            return when (className) {
+                COMPOSITE_ELEMENT_JVM_CLASS -> tryTransformCompositeElement(classfileBuffer)
+                STUB_INDEX_IMPL_JVM_CLASS -> tryTransformStubIndex(classfileBuffer)
+                else -> null
+            }
+        }
+        catch (e: Throwable) {
+            LOG.warn("Failed to instrument class $className", e)
+            throw e
+        }
+    }
+
+    private fun tryTransformCompositeElement(classBytes: ByteArray): ByteArray {
+        val reader = ClassReader(classBytes)
+        val writer = ClassWriter(reader, COMPUTE_MAXS or COMPUTE_FRAMES)
+
+        val classVisitor = object: ClassVisitor(ASM_API, writer) {
+            override fun visitMethod(
+                access: Int,
+                name: String?,
+                descriptor: String?,
+                signature: String?,
+                exceptions: Array<out String>?
+            ): MethodVisitor {
+                if (name != "createPsiNoLock") {
+                    return super.visitMethod(access, name, descriptor, signature, exceptions)
+                }
+
+                val methodWriter = cv.visitMethod(access, name, descriptor, signature, exceptions)
+
+                return object: AdviceAdapter(ASM_API, methodWriter, access, name, descriptor) {
+                    override fun onMethodExit(opcode: Int) {
+                        mv.visitInsn(Opcodes.DUP)
+                        mv.visitMethodInsn(
+                            Opcodes.INVOKESTATIC,
+                            HOOK_CLASS_JVM_NAME,
+                            ON_PSI_ELEMENT_CREATE.name,
+                            ON_PSI_ELEMENT_CREATE.descriptor,
+                            false
+                        )
+                    }
+                }
+            }
+        }
+
+        reader.accept(classVisitor, SKIP_FRAMES)
+        return writer.toByteArray()
+    }
+
+    private fun tryTransformStubIndex(classBytes: ByteArray): ByteArray {
+        val reader = ClassReader(classBytes)
+        val writer = ClassWriter(reader, COMPUTE_MAXS or COMPUTE_FRAMES)
+
+        val classVisitor = object: ClassVisitor(ASM_API, writer) {
+            override fun visitMethod(
+                access: Int,
+                name: String?,
+                descriptor: String?,
+                signature: String?,
+                exceptions: Array<out String>?
+            ): MethodVisitor {
+                if (name != "processElements" || descriptor != "(Lcom/intellij/psi/stubs/StubIndexKey;Ljava/lang/Object;Lcom/intellij/openapi/project/Project;Lcom/intellij/psi/search/GlobalSearchScope;Lcom/intellij/util/indexing/IdFilter;Ljava/lang/Class;Lcom/intellij/util/Processor;)Z") {
+                    return super.visitMethod(access, name, descriptor, signature, exceptions)
+                }
+
+                val methodWriter = cv.visitMethod(access, name, descriptor, signature, exceptions)
+
+                return object: AdviceAdapter(ASM_API, methodWriter, access, name, descriptor) {
+                    override fun onMethodEnter() {
+                        mv.visitVarInsn(Opcodes.ALOAD, 7)
+                        mv.visitMethodInsn(
+                            Opcodes.INVOKESTATIC,
+                            HOOK_CLASS_JVM_NAME,
+                            ON_STUB_INDEX_PROCESSOR_CREATE.name,
+                            ON_STUB_INDEX_PROCESSOR_CREATE.descriptor,
+                            false
+                        )
+                        mv.visitVarInsn(Opcodes.ASTORE, 7)
+                    }
+                }
+            }
+        }
+
+        reader.accept(classVisitor, SKIP_FRAMES)
+        return writer.toByteArray()
+    }
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTree.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTree.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import java.io.File
+import java.util.*
+
+/** A tree containing VirtualFile statistics. */
+interface VirtualFileTree {
+    companion object {
+        val EMPTY: VirtualFileTree = MutableVirtualFileTree.createRoot()
+    }
+
+    val name: String
+    val stubIndexAccesses: Int
+    val psiElementWraps: Int
+    val children: Map<String, VirtualFileTree>
+
+    val isDirectory: Boolean get() = children.isNotEmpty()
+    val isFile: Boolean get() = children.isEmpty()
+
+    fun statEquals(other: VirtualFileTree): Boolean =
+        stubIndexAccesses == other.stubIndexAccesses && psiElementWraps == other.psiElementWraps
+}
+
+class MutableVirtualFileTree(
+    override val name: String
+): VirtualFileTree {
+    companion object {
+        fun createRoot() = MutableVirtualFileTree("[root]")
+    }
+
+    override var stubIndexAccesses: Int = 0
+    override var psiElementWraps: Int = 0
+    override val children: MutableMap<String, MutableVirtualFileTree> = TreeMap()
+
+    fun clear() {
+        fun clearImpl(tree: MutableVirtualFileTree) {
+            tree.stubIndexAccesses = 0
+            tree.psiElementWraps = 0
+            for (child in tree.children.values) {
+                clearImpl(child)
+            }
+        }
+        clearImpl(this)
+    }
+
+    fun accumulate(tree: VirtualFileTree) {
+        for ((childName, child) in tree.children) {
+            val thisChild = children.getOrPut(childName) { MutableVirtualFileTree(childName) }
+            thisChild.accumulate(child)
+        }
+
+        stubIndexAccesses += tree.stubIndexAccesses
+        psiElementWraps += tree.psiElementWraps
+    }
+
+    fun accumulate(
+        path: String,
+        stubIndexAccesses: Int = 0,
+        psiElementWraps: Int = 0
+    ) {
+        val parts = getParts(path)
+        var tree = this
+        tree.stubIndexAccesses += stubIndexAccesses
+        tree.psiElementWraps += psiElementWraps
+
+        for (part in parts) {
+            val child = tree.children.getOrPut(part) { MutableVirtualFileTree(part) }
+            child.stubIndexAccesses += stubIndexAccesses
+            child.psiElementWraps += psiElementWraps
+            tree = child
+        }
+    }
+
+    private fun getParts(path: String): List<String> {
+        var file = File(path)
+        val parts = mutableListOf<String>()
+        do {
+            val name = file.name
+            parts.add(name)
+            file = file.parentFile
+        }
+        while (file.parentFile != null)
+
+        return parts.reversed()
+    }
+
+    override fun toString(): String = name
+}
+
+/** A VirtualFileTree path where each part contains a reference to each node. */
+class VirtualFileTreePath(val parts: Array<VirtualFileTree>)
+
+interface TreePatchEventListener {
+    /**
+     * Called when the diff contains a new pending tree node.
+     * @param path A path of tree nodes that leads up to {@code parent}
+     * @param parent The parent of the new tree node
+     * @param child The new tree node
+     */
+    fun onTreeInsert(
+        path: VirtualFileTreePath,
+        parent: MutableVirtualFileTree,
+        child: MutableVirtualFileTree
+    )
+
+    /**
+     * Called when the diff contains a modified tree node.
+     * @param path A path of tree nodes that leads up to {@code parent}
+     * @param parent The parent of the modified tree node
+     * @param child The existing tree node pending for modification
+     * @param newChild A new tree node containing the modified values
+     */
+    fun onTreeChange(
+        path: VirtualFileTreePath,
+        parent: MutableVirtualFileTree,
+        child: MutableVirtualFileTree,
+        newChild: VirtualFileTree
+    )
+
+    /**
+     * Called when the diff contains a removed tree node.
+     * @param path A path of tree nodes that leads up to {@code parent}
+     * @param parent The parent of the removed tree node
+     * @param child The existing tree node pending for removal
+     */
+    fun onTreeRemove(
+        path: VirtualFileTreePath,
+        parent: MutableVirtualFileTree,
+        child: MutableVirtualFileTree
+    )
+}
+
+/** A recursive diff between two VirtualFileTree instances. */
+class VirtualFileTreeDiff private constructor(
+    private val underlyingTree: MutableVirtualFileTree,
+    private val newTree: VirtualFileTree,
+    private val insertedChildren: Map<String, VirtualFileTreeDiff>,
+    private val modifiedChildren: Map<String, VirtualFileTreeDiff>,
+    private val removedChildren: Map<String, MutableVirtualFileTree>
+): VirtualFileTree {
+    override val name get() = underlyingTree.name
+    override val stubIndexAccesses: Int get() = underlyingTree.stubIndexAccesses
+    override val psiElementWraps: Int get() = underlyingTree.psiElementWraps
+    override val children: Map<String, VirtualFileTree> get() = underlyingTree.children
+
+    /** Recursively applies a patch function to the @{code underlyingTree} based on the diff. */
+    fun applyPatch(listener: TreePatchEventListener) {
+        fun patchImpl(
+            pathBuilder: Stack<MutableVirtualFileTree>,
+            treeDiff: VirtualFileTreeDiff
+        ) {
+            val underlyingTree = treeDiff.underlyingTree
+            pathBuilder.push(underlyingTree)
+
+            val path = VirtualFileTreePath(pathBuilder.toTypedArray())
+
+            for ((childName, newChild) in treeDiff.insertedChildren) {
+                val child = underlyingTree.children[childName]
+                check(child == null)
+                listener.onTreeInsert(path, underlyingTree, newChild.underlyingTree)
+                patchImpl(pathBuilder, newChild)
+            }
+
+            for ((childName, newChild) in treeDiff.modifiedChildren) {
+                val child = underlyingTree.children[childName]
+                check(child === newChild.underlyingTree)
+                listener.onTreeChange(
+                    path,
+                    underlyingTree,
+                    newChild.underlyingTree,
+                    newChild.newTree
+                )
+                patchImpl(pathBuilder, newChild)
+            }
+
+            for (oldChild in treeDiff.removedChildren.values) {
+                listener.onTreeRemove(path, underlyingTree, oldChild)
+            }
+
+            pathBuilder.pop()
+        }
+
+        val pathBuilder = Stack<MutableVirtualFileTree>()
+        patchImpl(pathBuilder, this)
+    }
+
+    companion object {
+        /** Creates a diff based on the changes from {@code oldTree} to {@param newTree}. */
+        fun create(
+            oldTree: MutableVirtualFileTree?,
+            newTree: VirtualFileTree
+        ): VirtualFileTreeDiff {
+            val insertedChildren = LinkedHashMap<String, VirtualFileTreeDiff>()
+            val modifiedChildren = LinkedHashMap<String, VirtualFileTreeDiff>()
+            val removedChildren = LinkedHashMap<String, MutableVirtualFileTree>()
+
+            if (oldTree != null) {
+                for ((childName, newChild) in newTree.children) {
+                    val oldChild = oldTree.children[childName]
+                    val childDiff = create(oldChild, newChild)
+                    if (oldChild == null) {
+                        insertedChildren[childDiff.name] = childDiff
+                    }
+                    else if (!oldChild.statEquals(newChild)) {
+                        modifiedChildren[childDiff.name] = childDiff
+                    }
+                }
+
+                for ((childName, oldChild) in oldTree.children) {
+                    val newChild = newTree.children[childName]
+                    if (newChild == null) {
+                        removedChildren[childName] = oldChild
+                    }
+                }
+
+                return VirtualFileTreeDiff(
+                    oldTree, newTree, insertedChildren, modifiedChildren, removedChildren
+                )
+            }
+            else {
+                for ((childName, child) in newTree.children) {
+                    insertedChildren[childName] = create(null, child)
+                }
+
+                return VirtualFileTreeDiff(
+                    MutableVirtualFileTree(newTree.name).apply {
+                        stubIndexAccesses = newTree.stubIndexAccesses
+                        psiElementWraps = newTree.psiElementWraps
+                    },
+                    newTree,
+                    insertedChildren,
+                    modifiedChildren,
+                    removedChildren
+                )
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,13 @@
             <add-to-group group-id="HelpDiagnosticTools" anchor="after"
                           relative-to-action="Performance.ActivityMonitor" />
         </action>
+        <action text="VFS Tracer..."
+                id="com.google.idea.VfsTracer"
+                class="com.google.idea.perf.vfstracer.VfsTracerAction"
+                description="Trace IDE PSI tree to get reparse events and overhead in real time">
+            <add-to-group group-id="HelpDiagnosticTools" anchor="after"
+                          relative-to-action="Performance.ActivityMonitor" />
+        </action>
     </actions>
 
     <application-components>

--- a/src/test/java/com/google/idea/perf/vfstracer/VirtualFileTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/vfstracer/VirtualFileTreeTest.kt
@@ -75,7 +75,7 @@ private class ChangeLog: TreePatchEventListener {
         logger.appendln("inserted $pathString $stubIndexAccesses $psiElementWraps")
     }
 
-    override fun onTreeChange(
+    override fun onTreeModify(
         path: VirtualFileTreePath,
         parent: MutableVirtualFileTree,
         child: MutableVirtualFileTree,
@@ -117,7 +117,7 @@ class VirtualFileTreeTest {
         assertPath(4, 3, tree, "com", "example")
         assertPath(0, 1, tree, "com", "example", "Main.java")
         assertPath(4, 2, tree, "com", "example", "util")
-        assertPath(2, 1, tree, "com", "example", "util", "B.java")
+        assertPath(2, 1, tree, "com", "example", "util", "A.java")
         assertPath(2, 1, tree, "com", "example", "util", "B.java")
         assertPath(300, 0, tree, "java")
         assertPath(300, 0, tree, "java", "lang")
@@ -180,7 +180,7 @@ class VirtualFileTreeTest {
         assertPath(4, 3, accumulatedTree, "com", "example")
         assertPath(0, 1, accumulatedTree, "com", "example", "Main.java")
         assertPath(4, 2, accumulatedTree, "com", "example", "util")
-        assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
+        assertPath(2, 1, accumulatedTree, "com", "example", "util", "A.java")
         assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
         assertPath(300, 0, accumulatedTree, "java")
         assertPath(300, 0, accumulatedTree, "java", "lang")
@@ -193,7 +193,7 @@ class VirtualFileTreeTest {
         assertPath(4, 3, accumulatedTree, "com", "example")
         assertPath(0, 1, accumulatedTree, "com", "example", "Main.java")
         assertPath(4, 2, accumulatedTree, "com", "example", "util")
-        assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
+        assertPath(2, 1, accumulatedTree, "com", "example", "util", "A.java")
         assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
         assertPath(300, 0, accumulatedTree, "java")
         assertPath(300, 0, accumulatedTree, "java", "lang")

--- a/src/test/java/com/google/idea/perf/vfstracer/VirtualFileTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/vfstracer/VirtualFileTreeTest.kt
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.vfstracer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+private fun assertPath(
+    expectedStubIndexAccesses: Int,
+    expectedPsiElementWraps: Int,
+    tree: VirtualFileTree,
+    vararg path: String
+) {
+    var targetNode: VirtualFileTree? = tree
+    for (part in path) {
+        if (targetNode != null) {
+            targetNode = targetNode.children[part]
+        }
+        else {
+            fail("Node ${path.joinToString("/")} does not exist.")
+        }
+    }
+    assertEquals(expectedStubIndexAccesses, targetNode!!.stubIndexAccesses)
+    assertEquals(expectedPsiElementWraps, targetNode.psiElementWraps)
+}
+
+private fun MutableVirtualFileTree.addChild(
+    name: String,
+    stubIndexAccesses: Int,
+    psiElementWraps: Int,
+    applyFunc: MutableVirtualFileTree.() -> Unit = {}
+) {
+    val child = MutableVirtualFileTree(name)
+    child.stubIndexAccesses = stubIndexAccesses
+    child.psiElementWraps = psiElementWraps
+    applyFunc(child)
+    children[name] = child
+}
+
+private class ChangeLog: TreePatchEventListener {
+    companion object {
+        fun generate(diff: VirtualFileTreeDiff): String {
+            val generator = ChangeLog()
+            diff.applyPatch(generator)
+            return generator.logger.toString()
+        }
+    }
+
+    private val logger = StringBuilder()
+
+    override fun onTreeInsert(
+        path: VirtualFileTreePath,
+        parent: MutableVirtualFileTree,
+        child: MutableVirtualFileTree
+    ) {
+        val pathString = path.parts.joinToString("/") + "/${child.name}"
+        val stubIndexAccesses = child.stubIndexAccesses
+        val psiElementWraps = child.psiElementWraps
+        logger.appendln("inserted $pathString $stubIndexAccesses $psiElementWraps")
+    }
+
+    override fun onTreeChange(
+        path: VirtualFileTreePath,
+        parent: MutableVirtualFileTree,
+        child: MutableVirtualFileTree,
+        newChild: VirtualFileTree
+    ) {
+        val pathString = path.parts.joinToString("/") + "/${child.name}"
+        val stubIndexAccesses = newChild.stubIndexAccesses
+        val psiElementWraps = newChild.psiElementWraps
+        logger.appendln("modified $pathString $stubIndexAccesses $psiElementWraps")
+    }
+
+    override fun onTreeRemove(
+        path: VirtualFileTreePath,
+        parent: MutableVirtualFileTree,
+        child: MutableVirtualFileTree
+    ) {
+        val pathString = path.parts.joinToString("/") + "/${child.name}"
+        logger.appendln("removed $pathString")
+    }
+}
+
+class VirtualFileTreeTest {
+    init {
+        // Enforce LF line endings for developers on Windows.
+        System.setProperty("line.separator", "\n")
+    }
+
+    @Test
+    fun testPathAccumulator() {
+        val tree = MutableVirtualFileTree.createRoot()
+        tree.accumulate("/com/example/Main.java", psiElementWraps = 1)
+        tree.accumulate("/com/example/util/A.java", stubIndexAccesses = 2, psiElementWraps = 1)
+        tree.accumulate("/com/example/util/B.java",  stubIndexAccesses = 2, psiElementWraps = 1)
+        tree.accumulate("/java/lang/String.class", stubIndexAccesses = 100)
+        tree.accumulate("/java/lang/System.class", stubIndexAccesses = 200)
+
+        assertPath(304, 3, tree)
+        assertPath(4, 3, tree, "com")
+        assertPath(4, 3, tree, "com", "example")
+        assertPath(0, 1, tree, "com", "example", "Main.java")
+        assertPath(4, 2, tree, "com", "example", "util")
+        assertPath(2, 1, tree, "com", "example", "util", "B.java")
+        assertPath(2, 1, tree, "com", "example", "util", "B.java")
+        assertPath(300, 0, tree, "java")
+        assertPath(300, 0, tree, "java", "lang")
+        assertPath(100, 0, tree, "java", "lang", "String.class")
+        assertPath(200, 0, tree, "java", "lang", "System.class")
+    }
+
+    @Test
+    fun testTreeAccumulator() {
+        val accumulatedTree = MutableVirtualFileTree.createRoot()
+        val emptyTree = MutableVirtualFileTree.createRoot()
+        val tree1 = MutableVirtualFileTree.createRoot().apply {
+            stubIndexAccesses = 100
+            psiElementWraps = 1
+            addChild("com", 0, 1) {
+                addChild("example", 0, 1) {
+                    addChild("Main.java", 0, 1)
+                }
+            }
+            addChild("java", 100, 0) {
+                addChild("lang", 100, 0) {
+                    addChild("String.class", 100, 0)
+                }
+            }
+        }
+        val tree2 = MutableVirtualFileTree.createRoot().apply {
+            stubIndexAccesses = 204
+            psiElementWraps = 2
+            addChild("com", 4, 2) {
+                addChild("example", 4, 2) {
+                    addChild("util", 4, 2) {
+                        addChild("A.java", 2, 1)
+                        addChild("B.java", 2, 1)
+                    }
+                }
+            }
+            addChild("java", 200, 0) {
+                addChild("lang", 200, 0) {
+                    addChild("System.class", 200, 0)
+                }
+            }
+        }
+
+        accumulatedTree.accumulate(emptyTree)
+        assertPath(0, 0, accumulatedTree)
+        assertTrue(accumulatedTree.children.isEmpty())
+
+        accumulatedTree.accumulate(tree1)
+        assertPath(100, 1, accumulatedTree)
+        assertPath(0, 1, accumulatedTree, "com")
+        assertPath(0, 1, accumulatedTree, "com", "example")
+        assertPath(0, 1, accumulatedTree, "com", "example", "Main.java")
+        assertPath(100, 0, accumulatedTree, "java")
+        assertPath(100, 0, accumulatedTree, "java", "lang")
+        assertPath(100, 0, accumulatedTree, "java", "lang", "String.class")
+
+        accumulatedTree.accumulate(tree2)
+        assertPath(304, 3, accumulatedTree)
+        assertPath(4, 3, accumulatedTree, "com")
+        assertPath(4, 3, accumulatedTree, "com", "example")
+        assertPath(0, 1, accumulatedTree, "com", "example", "Main.java")
+        assertPath(4, 2, accumulatedTree, "com", "example", "util")
+        assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
+        assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
+        assertPath(300, 0, accumulatedTree, "java")
+        assertPath(300, 0, accumulatedTree, "java", "lang")
+        assertPath(100, 0, accumulatedTree, "java", "lang", "String.class")
+        assertPath(200, 0, accumulatedTree, "java", "lang", "System.class")
+
+        accumulatedTree.accumulate(emptyTree)
+        assertPath(304, 3, accumulatedTree)
+        assertPath(4, 3, accumulatedTree, "com")
+        assertPath(4, 3, accumulatedTree, "com", "example")
+        assertPath(0, 1, accumulatedTree, "com", "example", "Main.java")
+        assertPath(4, 2, accumulatedTree, "com", "example", "util")
+        assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
+        assertPath(2, 1, accumulatedTree, "com", "example", "util", "B.java")
+        assertPath(300, 0, accumulatedTree, "java")
+        assertPath(300, 0, accumulatedTree, "java", "lang")
+        assertPath(100, 0, accumulatedTree, "java", "lang", "String.class")
+        assertPath(200, 0, accumulatedTree, "java", "lang", "System.class")
+    }
+
+    @Test
+    fun testTreeDiff() {
+        val emptyTree = MutableVirtualFileTree.createRoot()
+        val tree1 = MutableVirtualFileTree.createRoot().apply {
+            stubIndexAccesses = 100
+            psiElementWraps = 1
+            addChild("com", 0, 1) {
+                addChild("example", 0, 1) {
+                    addChild("Main.java", 0, 1)
+                }
+            }
+            addChild("java", 100, 0) {
+                addChild("lang", 100, 0) {
+                    addChild("String.class", 100, 0)
+                    addChild("System.class", 100, 0)
+                }
+            }
+        }
+        val tree2 = MutableVirtualFileTree.createRoot().apply {
+            stubIndexAccesses = 304
+            psiElementWraps = 3
+            addChild("com", 4, 3) {
+                addChild("example", 4, 3) {
+                    addChild("Main.java", 0, 1)
+                    addChild("util", 4, 2) {
+                        addChild("A.java", 2, 1)
+                        addChild("B.java", 2, 1)
+                    }
+                }
+            }
+            addChild("java", 300, 0) {
+                addChild("lang", 300, 0) {
+                    addChild("String.class", 100, 0)
+                    addChild("System.class", 200, 0)
+                }
+            }
+        }
+
+        var diff = VirtualFileTreeDiff.create(emptyTree, emptyTree)
+        var changeLog = ChangeLog.generate(diff)
+        assertEquals("", changeLog)
+
+        diff = VirtualFileTreeDiff.create(emptyTree, tree1)
+        changeLog = ChangeLog.generate(diff)
+        assertEquals("""
+            inserted [root]/com 0 1
+            inserted [root]/com/example 0 1
+            inserted [root]/com/example/Main.java 0 1
+            inserted [root]/java 100 0
+            inserted [root]/java/lang 100 0
+            inserted [root]/java/lang/String.class 100 0
+            inserted [root]/java/lang/System.class 100 0
+            
+        """.trimIndent(), changeLog)
+
+        diff = VirtualFileTreeDiff.create(tree1, emptyTree)
+        changeLog = ChangeLog.generate(diff)
+        assertEquals("""
+            removed [root]/com
+            removed [root]/java
+            
+        """.trimIndent(), changeLog)
+
+        diff = VirtualFileTreeDiff.create(tree1, tree2)
+        changeLog = ChangeLog.generate(diff)
+        assertEquals("""
+            modified [root]/com 4 3
+            modified [root]/com/example 4 3
+            inserted [root]/com/example/util 4 2
+            inserted [root]/com/example/util/A.java 2 1
+            inserted [root]/com/example/util/B.java 2 1
+            modified [root]/java 300 0
+            modified [root]/java/lang 300 0
+            modified [root]/java/lang/System.class 200 0
+            
+        """.trimIndent(), changeLog)
+
+        diff = VirtualFileTreeDiff.create(tree2, tree1)
+        changeLog = ChangeLog.generate(diff)
+        assertEquals("""
+            modified [root]/com 0 1
+            modified [root]/com/example 0 1
+            removed [root]/com/example/util
+            modified [root]/java 100 0
+            modified [root]/java/lang 100 0
+            modified [root]/java/lang/System.class 100 0
+            
+        """.trimIndent(), changeLog)
+    }
+
+    @Test
+    fun testTreeFlattener() {
+        val emptyTree = MutableVirtualFileTree.createRoot()
+        val tree = MutableVirtualFileTree.createRoot().apply {
+            stubIndexAccesses = 304
+            psiElementWraps = 3
+            addChild("com", 4, 3) {
+                addChild("example", 4, 3) {
+                    addChild("Main.java", 0, 1)
+                    addChild("util", 4, 2) {
+                        addChild("A.java", 2, 1)
+                        addChild("B.java", 2, 1)
+                    }
+                }
+            }
+            addChild("java", 300, 0) {
+                addChild("lang", 300, 0) {
+                    addChild("String.class", 100, 0)
+                    addChild("System.class", 200, 0)
+                }
+            }
+        }
+
+        assertEquals(emptyList<VirtualFileStats>(), emptyTree.flattenedList())
+        assertEquals(listOf(
+            VirtualFileStats("com/example/Main.java", 0, 1),
+            VirtualFileStats("com/example/util/A.java", 2, 1),
+            VirtualFileStats("com/example/util/B.java", 2, 1),
+            VirtualFileStats("java/lang/String.class", 100, 0),
+            VirtualFileStats("java/lang/System.class", 200, 0)
+        ), tree.flattenedList())
+    }
+}


### PR DESCRIPTION
# Description

VFS tracer keeps track of PSI-related events and measures the accumulated time spent on it.

# Events

- **Stub index access:** Occurs when accessing a PSI element from a stub index
- **PSI element wrap:** Occurs when a PSI element has been created over an AST node

# Command Syntax

- **start:** Starts or resumes VFS tracing
- **stop:** Pauses VFS tracing
- **clear:** Zeroes out all virtual file stats
- **reset:** Removes all accumulated virtual file stats
