### PR TITLE
Make more refinements

### DIFF
--- a/agent/src/main/java/com/google/idea/perf/methodtracer/Argument.java
+++ b/agent/src/main/java/com/google/idea/perf/methodtracer/Argument.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf.agent;
+package com.google.idea.perf.methodtracer;
 
 import java.util.Objects;
 

--- a/agent/src/main/java/com/google/idea/perf/methodtracer/MethodTracerHook.java
+++ b/agent/src/main/java/com/google/idea/perf/methodtracer/MethodTracerHook.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf.agent;
+package com.google.idea.perf.methodtracer;
 
 /** Handler for method entry/exit events coming from instrumented bytecode. */
-public interface MethodListener {
+public interface MethodTracerHook {
     void enter(int methodId, Argument[] args);
     void leave(int methodId);
 }

--- a/agent/src/main/java/com/google/idea/perf/methodtracer/MethodTracerTrampoline.java
+++ b/agent/src/main/java/com/google/idea/perf/methodtracer/MethodTracerTrampoline.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf.agent;
+package com.google.idea.perf.methodtracer;
 
 /**
  * We cannot emit bytecode which calls directly into the tracer, because the tracer is loaded
@@ -23,13 +23,27 @@ package com.google.idea.perf.agent;
  *
  * So, we install a layer of indirection between these two worlds.
  */
-public class Trampoline {
-    public static MethodListener methodListener; // Set by the tracer.
+public final class MethodTracerTrampoline {
+    private static MethodTracerHook hook = new MethodTracerHookStub();
+
+    public static void installHook(MethodTracerHook newHook) {
+        hook = newHook;
+    }
 
     // These methods are called from instrumented bytecode.
     public static void enter(int methodId, Argument[] args) {
-        methodListener.enter(methodId, args);
+        hook.enter(methodId, args);
     }
 
-    public static void leave(int methodId) { methodListener.leave(methodId); }
+    public static void leave(int methodId) {
+        hook.leave(methodId);
+    }
+
+    private static final class MethodTracerHookStub implements MethodTracerHook {
+        @Override
+        public void enter(int methodId, Argument[] args) {}
+
+        @Override
+        public void leave(int methodId) {}
+    }
 }

--- a/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerTrampoline.java
+++ b/agent/src/main/java/com/google/idea/perf/vfstracer/VfsTracerTrampoline.java
@@ -35,7 +35,7 @@ public final class VfsTracerTrampoline {
         return hook.onStubIndexProcessorCreate(processor);
     }
 
-    private static class VfsTracerHookStub implements VfsTracerHook {
+    private static final class VfsTracerHookStub implements VfsTracerHook {
         @Override
         public void onPsiElementCreate(Object psiElement) {}
 

--- a/src/main/java/com/google/idea/perf/TracerView.kt
+++ b/src/main/java/com/google/idea/perf/TracerView.kt
@@ -16,11 +16,14 @@
 
 package com.google.idea.perf
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.MessageType
 import com.intellij.openapi.ui.popup.util.PopupUtil
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.textCompletion.TextFieldWithCompletion
+import java.awt.event.KeyEvent
+import java.awt.event.KeyListener
 import javax.swing.JProgressBar
 
 /** The content for filling the tracer dialog window. */
@@ -31,5 +34,23 @@ abstract class TracerView: JBPanel<TracerView>() {
 
     fun showCommandBalloon(message: String, type: MessageType) {
         PopupUtil.showBalloonForComponent(commandLine, message, type, true, null)
+    }
+
+    fun initEvents(controller: TracerController) {
+        val textComponent = commandLine.editor!!.contentComponent
+        textComponent.addKeyListener(object: KeyListener {
+            override fun keyTyped(e: KeyEvent) {}
+
+            override fun keyPressed(e: KeyEvent) {
+                if (e.keyCode == KeyEvent.VK_ENTER) {
+                    controller.handleRawCommandFromEdt(commandLine.text)
+                    ApplicationManager.getApplication().invokeLater {
+                        commandLine.text = ""
+                    }
+                }
+            }
+
+            override fun keyReleased(e: KeyEvent) {}
+        })
     }
 }

--- a/src/main/java/com/google/idea/perf/TracerView.kt
+++ b/src/main/java/com/google/idea/perf/TracerView.kt
@@ -67,30 +67,24 @@ abstract class TracerView: JBPanel<TracerView>() {
                         commandHistoryIndex = commandHistory.lastIndex
                     }
 
-                    getApplication().invokeLater {
-                        commandLine.text = ""
-                    }
+                    commandLine.text = ""
                 }
                 else if (e.keyCode == KeyEvent.VK_UP) {
-                    getApplication().invokeLater {
-                        if (commandHistoryIndex != -1) {
-                            if (commandHistoryIndex > 0 && commandLine.text.isNotEmpty()) {
-                                commandHistoryIndex--
-                            }
-                            val command = commandHistory[commandHistoryIndex]
-                            commandLine.text = command
+                    if (commandHistoryIndex != -1) {
+                        if (commandHistoryIndex > 0 && commandLine.text.isNotEmpty()) {
+                            commandHistoryIndex--
                         }
+                        val command = commandHistory[commandHistoryIndex]
+                        commandLine.text = command
                     }
                 }
-                else if (e.keyCode == KeyEvent.VK_UP) {
-                    getApplication().invokeLater {
-                        if (commandHistoryIndex != -1) {
-                            if (commandHistoryIndex < commandHistory.lastIndex) {
-                                commandHistoryIndex++
-                            }
-                            val command = commandHistory[commandHistoryIndex]
-                            commandLine.text = command
+                else if (e.keyCode == KeyEvent.VK_DOWN) {
+                    if (commandHistoryIndex != -1) {
+                        if (commandHistoryIndex < commandHistory.lastIndex) {
+                            commandHistoryIndex++
                         }
+                        val command = commandHistory[commandHistoryIndex]
+                        commandLine.text = command
                     }
                 }
             }

--- a/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerCommandPredictor.kt
@@ -17,12 +17,14 @@
 package com.google.idea.perf.cachedvaluetracer
 
 import com.google.idea.perf.CommandPredictor
-import com.google.idea.perf.util.fuzzySearch
+import com.google.idea.perf.util.FuzzySearcher
 import com.intellij.openapi.progress.ProgressManager
 
 class CachedValueTracerCommandPredictor: CommandPredictor {
     @Volatile
     private var classNames = emptyList<String>()
+
+    private val searcher = FuzzySearcher()
 
     fun setClasses(classes: Collection<Class<*>>) {
         classNames = classes.mapNotNull { it.canonicalName }
@@ -51,7 +53,7 @@ class CachedValueTracerCommandPredictor: CommandPredictor {
     }
 
     private fun predictToken(choices: Collection<String>, token: String): List<String> {
-        return fuzzySearch(choices, token, -1) { ProgressManager.checkCanceled() }
+        return searcher.search(choices, token, -1) { ProgressManager.checkCanceled() }
             .map { it.source }
     }
 

--- a/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerController.kt
+++ b/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerController.kt
@@ -16,9 +16,9 @@
 
 package com.google.idea.perf.cachedvaluetracer
 
+import com.google.idea.perf.AgentLoader
 import com.google.idea.perf.CommandCompletionProvider
 import com.google.idea.perf.TracerController
-import com.google.idea.perf.methodtracer.AgentLoader
 import com.google.idea.perf.util.fuzzyMatch
 import com.google.idea.perf.util.sumByLong
 import com.intellij.openapi.Disposable

--- a/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerView.kt
+++ b/src/main/java/com/google/idea/perf/cachedvaluetracer/CachedValueTracerView.kt
@@ -77,7 +77,7 @@ class CachedValueTracerDialog: DialogWrapper(null, null, false, IdeModalityType.
 }
 
 class CachedValueTracerView(parentDisposable: Disposable): TracerView() {
-    val controller = CachedValueTracerController(this, parentDisposable)
+    override val controller = CachedValueTracerController(this, parentDisposable)
     override val commandLine: TextFieldWithCompletion
     override val progressBar: JProgressBar
     override val refreshTimeLabel: JBLabel

--- a/src/main/java/com/google/idea/perf/methodtracer/ArgSet.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/ArgSet.kt
@@ -16,8 +16,6 @@
 
 package com.google.idea.perf.methodtracer
 
-import com.google.idea.perf.agent.Argument
-
 class ArgSet(val items: Array<Argument>) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTree.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTree.kt
@@ -18,66 +18,42 @@ package com.google.idea.perf.methodtracer
 
 /** A call tree, represented recursively. */
 interface CallTree {
-    interface Stats {
-        val callCount: Long
-        val wallTime: Long
-        val maxWallTime: Long
-    }
-
-    val tracepoint: Tracepoint
-    val stats: Stats
-    val argSetStats: Map<ArgSet, Stats>
-    val children: Map<Tracepoint, CallTree>
+    val methodCall: MethodCall
+    val callCount: Long
+    val wallTime: Long
+    val maxWallTime: Long
+    val children: Map<MethodCall, CallTree>
 }
 
 /** A mutable call tree implementation. */
 class MutableCallTree(
-    override val tracepoint: Tracepoint
+    override val methodCall: MethodCall
 ): CallTree {
-    class MutableStats: CallTree.Stats {
-        override var callCount: Long = 0L
-        override var wallTime: Long = 0L
-        override var maxWallTime: Long = 0L
-
-        fun accumulate(other: CallTree.Stats) {
-            callCount += other.callCount
-            wallTime += other.wallTime
-            maxWallTime = maxOf(maxWallTime, other.maxWallTime)
-        }
-
-        fun clear() {
-            callCount = 0L
-            wallTime = 0L
-            maxWallTime = 0L
-        }
-    }
-
-    override val stats = MutableStats()
-    override val argSetStats: MutableMap<ArgSet, MutableStats> = LinkedHashMap()
-    override val children: MutableMap<Tracepoint, MutableCallTree> = LinkedHashMap()
+    override var callCount: Long = 0L
+    override var wallTime: Long = 0L
+    override var maxWallTime: Long = 0L
+    override val children: MutableMap<MethodCall, MutableCallTree> = LinkedHashMap()
 
     /** Accumulates the data from another call tree into this one. */
     fun accumulate(other: CallTree) {
-        require(other.tracepoint == tracepoint) {
+        require(other.methodCall == methodCall) {
             "Doesn't make sense to sum call tree nodes representing different tracepoints"
         }
 
-        stats.accumulate(other.stats)
+        callCount += other.callCount
+        wallTime += other.wallTime
+        maxWallTime = maxOf(maxWallTime, other.maxWallTime)
 
-        for ((argSet, stats) in other.argSetStats) {
-            val thisStats = argSetStats.getOrPut(argSet) { MutableStats() }
-            thisStats.accumulate(stats)
-        }
-
-        for ((childTracepoint, otherChild) in other.children) {
-            val child = children.getOrPut(childTracepoint) { MutableCallTree(childTracepoint) }
+        for ((childMethodCall, otherChild) in other.children) {
+            val child = children.getOrPut(childMethodCall) { MutableCallTree(childMethodCall) }
             child.accumulate(otherChild)
         }
     }
 
     fun clear() {
-        stats.clear()
+        callCount = 0L
+        wallTime = 0L
+        maxWallTime = 0L
         children.values.forEach(MutableCallTree::clear)
-        argSetStats.forEach { (_, stats) -> stats.clear() }
     }
 }

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTreeBuilder.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTreeBuilder.kt
@@ -16,8 +16,6 @@
 
 package com.google.idea.perf.methodtracer
 
-import com.google.idea.perf.agent.Argument
-
 // Things to improve:
 // - Think about the behavior we want for recursive calls.
 // - Keep track of CPU time too by using ManagementFactory.getThreadMXBean().

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTreeBuilder.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTreeBuilder.kt
@@ -37,6 +37,7 @@ class CallTreeBuilder(
         val now = clock.sample()
         root.startWallTime = now
         root.continuedWallTime = now
+        root.tracepointFlags = TracepointFlags.TRACE_WALL_TIME
     }
 
     interface Clock {
@@ -146,9 +147,12 @@ class CallTreeBuilder(
             val nodeArgs = node.argSet
             val elapsedTime = now - node.continuedWallTime
             val elapsedTimeFromStart = now - node.startWallTime
-            node.stats.wallTime += elapsedTime
-            node.stats.maxWallTime = maxOf(node.stats.maxWallTime, elapsedTimeFromStart)
-            node.continuedWallTime = now
+
+            if ((node.tracepointFlags and TracepointFlags.TRACE_WALL_TIME) != 0) {
+                node.stats.wallTime += elapsedTime
+                node.stats.maxWallTime = maxOf(node.stats.maxWallTime, elapsedTimeFromStart)
+                node.continuedWallTime = now
+            }
 
             if (nodeArgs != null) {
                 val stats = node.argSetStats.getOrPut(nodeArgs) { Tree.MutableStats() }

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTreeManager.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTreeManager.kt
@@ -39,11 +39,11 @@ object CallTreeManager {
     // Synchronized by monitor lock.
     private val allThreadState = mutableListOf<ThreadState>()
 
-    fun enter(tracepoint: Tracepoint, args: Array<Argument>?) {
+    fun enter(methodCall: MethodCall) {
         val state = threadState.get()
         synchronized(state) {
             doPreventingRecursion(state) {
-                state.callTreeBuilder.push(tracepoint, args)
+                state.callTreeBuilder.push(methodCall)
             }
         }
     }

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTreeManager.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTreeManager.kt
@@ -16,8 +16,6 @@
 
 package com.google.idea.perf.methodtracer
 
-import com.google.idea.perf.agent.Argument
-
 // Things to improve:
 // - GC the state for dead threads.
 

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodCall.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodCall.kt
@@ -16,16 +16,13 @@
 
 package com.google.idea.perf.methodtracer
 
-class ArgSet(val items: Array<Argument>) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ArgSet
-        return items.contentEquals(other.items)
+data class MethodCall(
+    val tracepoint: Tracepoint,
+    val arguments: String?
+) {
+    companion object {
+        val ROOT = MethodCall(Tracepoint.ROOT, null)
     }
 
-    override fun hashCode(): Int = items.contentHashCode()
-
-    override fun toString(): String = items.map { it.value }.joinToString(", ")
+    override fun toString(): String = "$tracepoint(${arguments ?: ""})"
 }

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommand.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommand.kt
@@ -34,6 +34,10 @@ sealed class MethodTracerCommand {
         val target: TraceTarget?
     ): MethodTracerCommand()
 
+    /**
+     * Checks for syntax errors. If no error exists, then all fields within this structure are
+     * non-null values.
+     */
     val errors: List<String>
         get() = when (this) {
             Unknown -> listOf("Unknown command")

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
@@ -44,8 +44,11 @@ class MethodTracerCommandPredictor: CommandPredictor {
             )
             1 -> when (command) {
                 is MethodTracerCommand.Trace -> {
-                    val options = predictToken(listOf("all", "count", "wall-time"), token)
-                    val classes = predictToken(classNames, token)
+                    val options = predictToken(listOf("*", "all", "count", "wall-time"), token)
+                    val classes = when (command.enable) {
+                        true -> predictToken(classNames, token)
+                        false -> predictToken(TracerConfig.getTracedClassNames(), token)
+                    }
                     return options + classes
                 }
                 else -> emptyList()
@@ -81,7 +84,7 @@ class MethodTracerCommandPredictor: CommandPredictor {
         }
         val methodNames = clazz?.methods?.map { it.name.substringAfter('$') }
         if (methodNames != null) {
-            return predictToken(methodNames, token)
+            return predictToken(listOf("*") + methodNames, token)
         }
         return emptyList()
     }

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
@@ -16,6 +16,7 @@
 
 package com.google.idea.perf.methodtracer
 
+import com.google.idea.perf.AgentLoader
 import com.google.idea.perf.CommandPredictor
 import com.google.idea.perf.util.fuzzySearch
 import com.intellij.openapi.progress.ProgressManager

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerCommandPredictor.kt
@@ -18,12 +18,14 @@ package com.google.idea.perf.methodtracer
 
 import com.google.idea.perf.AgentLoader
 import com.google.idea.perf.CommandPredictor
-import com.google.idea.perf.util.fuzzySearch
+import com.google.idea.perf.util.FuzzySearcher
 import com.intellij.openapi.progress.ProgressManager
 
 class MethodTracerCommandPredictor: CommandPredictor {
     @Volatile
     private var classNames = emptyList<String>()
+
+    private val searcher = FuzzySearcher()
 
     fun setClasses(classes: Collection<Class<*>>) {
         classNames = classes.mapNotNull { it.canonicalName }
@@ -69,7 +71,7 @@ class MethodTracerCommandPredictor: CommandPredictor {
     }
 
     private fun predictToken(choices: Collection<String>, token: String): List<String> {
-        return fuzzySearch(choices, token, -1) { ProgressManager.checkCanceled() }
+        return searcher.search(choices, token, -1) { ProgressManager.checkCanceled() }
             .map { it.source }
     }
 

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -60,7 +60,7 @@ class MethodTracerController(
     }
 
     private var instrumentationInitialized = false
-    private var callTree = MutableCallTree(Tracepoint.ROOT)
+    private var callTree = MutableCallTree(MethodCall.ROOT)
     private val predictor = MethodTracerCommandPredictor()
     val autocomplete = CommandCompletionProvider(predictor)
 
@@ -88,12 +88,13 @@ class MethodTracerController(
     override fun updateUi() {
         val allStats = TreeAlgorithms.computeFlatTracepointStats(callTree)
         val visibleStats = allStats.filter { it.tracepoint != Tracepoint.ROOT }
-        val argStatMap = ArgStatMap.fromCallTree(callTree)
+
+        val visibleArgStats = ArgStatMap.fromCallTree(callTree, false)
 
         // We use invokeAndWait to ensure proper backpressure for the data refresh loop.
         getApplication().invokeAndWait {
             view.listView.setTracepointStats(visibleStats)
-            view.updateTabs(argStatMap)
+            view.updateTabs(visibleArgStats)
         }
     }
 
@@ -126,7 +127,7 @@ class MethodTracerController(
                 updateUi()
             }
             is MethodTracerCommand.Reset -> {
-                callTree = MutableCallTree(Tracepoint.ROOT)
+                callTree = MutableCallTree(MethodCall.ROOT)
                 updateUi()
             }
             is MethodTracerCommand.Trace -> {

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerController.kt
@@ -57,9 +57,9 @@ class MethodTracerController(
 ): TracerController("Method Tracer", view), Disposable {
     companion object {
         const val AUTOCOMPLETE_RELOAD_INTERVAL = 120L
+        private var instrumentationInitialized = false
     }
 
-    private var instrumentationInitialized = false
     private var callTree = MutableCallTree(MethodCall.ROOT)
     private val predictor = MethodTracerCommandPredictor()
     val autocomplete = CommandCompletionProvider(predictor)

--- a/src/main/java/com/google/idea/perf/methodtracer/MethodTracerView.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/MethodTracerView.kt
@@ -84,7 +84,7 @@ class MethodTracerDialog: DialogWrapper(null, null, false, IdeModalityType.IDE, 
 
 /** The content filling the tracer dialog window. */
 class MethodTracerView(parentDisposable: Disposable): TracerView() {
-    val controller = MethodTracerController(this, parentDisposable)
+    override val controller = MethodTracerController(this, parentDisposable)
     override val commandLine: TextFieldWithCompletion
     override val progressBar: JProgressBar
     override val refreshTimeLabel: JBLabel

--- a/src/main/java/com/google/idea/perf/methodtracer/TracepointStats.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracepointStats.kt
@@ -19,9 +19,9 @@ package com.google.idea.perf.methodtracer
 /** Encapsulates aggregate statistic for a single tracepoint. */
 class TracepointStats(
     val tracepoint: Tracepoint,
-    var callCount: Long = 0,
-    var wallTime: Long = 0,
-    var maxWallTime: Long = 0
+    var callCount: Long = 0L,
+    var wallTime: Long = 0L,
+    var maxWallTime: Long = 0L
 )
 
 object TreeAlgorithms {
@@ -33,24 +33,24 @@ object TreeAlgorithms {
         val allStats = mutableMapOf<Tracepoint, TracepointStats>()
         val ancestors = mutableSetOf<Tracepoint>()
 
-        fun bfs(node: CallTree) {
-            val nonRecursive = node.tracepoint !in ancestors
-            val stats = allStats.getOrPut(node.tracepoint) { TracepointStats(node.tracepoint) }
-            stats.callCount += node.stats.callCount
+        fun dfs(node: CallTree) {
+            val nonRecursive = node.methodCall.tracepoint !in ancestors
+            val stats = allStats.getOrPut(node.methodCall.tracepoint) { TracepointStats(node.methodCall.tracepoint) }
+            stats.callCount += node.callCount
             if (nonRecursive) {
-                stats.wallTime += node.stats.wallTime
-                stats.maxWallTime = stats.maxWallTime.coerceAtLeast(node.stats.maxWallTime)
-                ancestors.add(node.tracepoint)
+                stats.wallTime += node.wallTime
+                stats.maxWallTime = maxOf(stats.maxWallTime, node.maxWallTime)
+                ancestors.add(node.methodCall.tracepoint)
             }
             for (child in node.children.values) {
-                bfs(child)
+                dfs(child)
             }
             if (nonRecursive) {
-                ancestors.remove(node.tracepoint)
+                ancestors.remove(node.methodCall.tracepoint)
             }
         }
 
-        bfs(root)
+        dfs(root)
         assert(ancestors.isEmpty())
 
         return allStats.values.toList()

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -329,4 +329,9 @@ object TracerConfig {
             parameters = properties.parameters
         )
     }
+
+    fun getTracedClassNames(): List<String> {
+        val classNames = lock.withLock { classConfigs.keys.toList() }
+        return classNames.map { it.replace('/', '.') }
+    }
 }

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -16,7 +16,7 @@
 
 package com.google.idea.perf.methodtracer
 
-import com.google.idea.perf.agent.MethodListener
+import com.google.idea.perf.AgentLoader
 import com.google.idea.perf.util.ConcurrentAppendOnlyList
 import com.intellij.util.PatternUtil
 import org.objectweb.asm.Type
@@ -280,7 +280,7 @@ object TracerConfig {
     }
 
     /**
-     * Returns the method ID to be used for [MethodListener] events,
+     * Returns the method ID to be used for [MethodTracerHook] events,
      * or null if the given method should not be instrumented.
      */
     fun getMethodId(classJvmName: String, methodName: String, methodDesc: String): Int? {

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -310,6 +310,9 @@ object TracerConfig {
 
     fun getTracepoint(methodId: Int): Tracepoint = tracepoints.get(methodId)
 
+    fun getMethodCall(methodId: Int, arguments: Array<Argument>?) =
+        MethodCall(getTracepoint(methodId), arguments?.map { it.value }?.joinToString(", "))
+
     private fun createTracepoint(
         classJvmName: String,
         methodName: String,

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -45,7 +45,11 @@ object TracerConfig {
     private class TracepointProperties(
         val flags: Int = 0,
         val parameters: Int = 0
-    )
+    ) {
+        companion object {
+            val DISABLED = TracepointProperties()
+        }
+    }
 
     /** Specifies which methods to instrument for a given class. */
     private class ClassConfig {
@@ -108,7 +112,7 @@ object TracerConfig {
                 val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
                 classConfig.methodIds.getOrPut(methodSignature) {
                     val tracepoint = createTracepoint(
-                        classJvmName, method.name, methodDesc, TracepointProperties()
+                        classJvmName, method.name, methodDesc, TracepointProperties.DISABLED
                     )
                     tracepoints.append(tracepoint)
                 }
@@ -160,7 +164,7 @@ object TracerConfig {
                 if (methodId == null) {
                     val tracepoint = createTracepoint(
                         classJvmName, methodName, methodDesc,
-                        TracepointProperties(flags, parameterBits)
+                        TracepointProperties.DISABLED
                     )
                     methodId = tracepoints.append(tracepoint)
                     entry.setValue(methodId)

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerConfig.kt
@@ -43,13 +43,9 @@ object TracerConfig {
     private val classConfigs = mutableMapOf<String, ClassConfig>() // Keyed by 'JVM' class name.
 
     private class TracepointProperties(
-        val flags: Int = TracepointFlags.TRACE_ALL,
+        val flags: Int = 0,
         val parameters: Int = 0
-    ) {
-        companion object {
-            val DEFAULT = TracepointProperties()
-        }
-    }
+    )
 
     /** Specifies which methods to instrument for a given class. */
     private class ClassConfig {
@@ -112,7 +108,7 @@ object TracerConfig {
                 val classConfig = classConfigs.getOrPut(classJvmName) { ClassConfig() }
                 classConfig.methodIds.getOrPut(methodSignature) {
                     val tracepoint = createTracepoint(
-                        classJvmName, method.name, methodDesc, TracepointProperties.DEFAULT
+                        classJvmName, method.name, methodDesc, TracepointProperties()
                     )
                     tracepoints.append(tracepoint)
                 }

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerMethodListener.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerMethodListener.kt
@@ -19,8 +19,8 @@ package com.google.idea.perf.methodtracer
 /** Dispatches method entry/exit events to the [CallTreeManager]. */
 class TracerMethodListener: MethodTracerHook {
     override fun enter(methodId: Int, args: Array<Argument>?) {
-        val tracepoint = TracerConfig.getTracepoint(methodId)
-        CallTreeManager.enter(tracepoint, args)
+        val methodCall = TracerConfig.getMethodCall(methodId, args)
+        CallTreeManager.enter(methodCall)
     }
 
     override fun leave(methodId: Int) {
@@ -33,8 +33,8 @@ class TracerMethodListener: MethodTracerHook {
             // Trigger class loading for CallTreeManager early so that it doesn't happen
             // during tracing. This reduces the chance of invoking an instrumented method
             // from a tracing hook (causing infinite recursion).
-            CallTreeManager.enter(Tracepoint.ROOT, null)
-            CallTreeManager.leave(Tracepoint.ROOT)
+            CallTreeManager.enter(MethodCall.ROOT)
+            CallTreeManager.leave(MethodCall.ROOT.tracepoint)
             CallTreeManager.collectAndReset()
         }
     }

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerMethodListener.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerMethodListener.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.methodtracer
+
+/** Dispatches method entry/exit events to the [CallTreeManager]. */
+class TracerMethodListener: MethodTracerHook {
+    override fun enter(methodId: Int, args: Array<Argument>?) {
+        val tracepoint = TracerConfig.getTracepoint(methodId)
+        CallTreeManager.enter(tracepoint, args)
+    }
+
+    override fun leave(methodId: Int) {
+        val tracepoint = TracerConfig.getTracepoint(methodId)
+        CallTreeManager.leave(tracepoint)
+    }
+
+    companion object {
+        init {
+            // Trigger class loading for CallTreeManager early so that it doesn't happen
+            // during tracing. This reduces the chance of invoking an instrumented method
+            // from a tracing hook (causing infinite recursion).
+            CallTreeManager.enter(Tracepoint.ROOT, null)
+            CallTreeManager.leave(Tracepoint.ROOT)
+            CallTreeManager.collectAndReset()
+        }
+    }
+}

--- a/src/main/java/com/google/idea/perf/methodtracer/TracerMethodTransformer.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/TracerMethodTransformer.kt
@@ -16,8 +16,6 @@
 
 package com.google.idea.perf.methodtracer
 
-import com.google.idea.perf.agent.Argument
-import com.google.idea.perf.agent.Trampoline
 import com.intellij.openapi.diagnostic.Logger
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassReader.SKIP_FRAMES
@@ -48,9 +46,9 @@ class TracerMethodTransformer: ClassFileTransformer {
         private val LOG = Logger.getInstance(TracerMethodTransformer::class.java)
         private const val ASM_API = ASM8
 
-        private val TRAMPOLINE_CLASS_NAME = Type.getType(Trampoline::class.java).internalName
-        private val TRAMPOLINE_ENTER_METHOD = Method.getMethod(Trampoline::enter.javaMethod)
-        private val TRAMPOLINE_LEAVE_METHOD = Method.getMethod(Trampoline::leave.javaMethod)
+        private val TRAMPOLINE_CLASS_NAME = Type.getType(MethodTracerTrampoline::class.java).internalName
+        private val TRAMPOLINE_ENTER_METHOD = Method.getMethod(MethodTracerTrampoline::enter.javaMethod)
+        private val TRAMPOLINE_LEAVE_METHOD = Method.getMethod(MethodTracerTrampoline::leave.javaMethod)
 
         private val ARGUMENT_NAME = Type.getType(Argument::class.java).internalName
         private val ARGUMENT_CONSTRUCTOR = Method.getMethod(Argument::class.constructors.first().javaConstructor)

--- a/src/main/java/com/google/idea/perf/util/Matching.kt
+++ b/src/main/java/com/google/idea/perf/util/Matching.kt
@@ -28,6 +28,7 @@ class MatchResult(val source: String, val formattedSource: String) {
 class FuzzySearcher {
     private val impl = FuzzySearcherImpl()
 
+    /** Searches on a list of strings based on an approximate pattern. */
     fun search(
         sources: Collection<String>,
         pattern: String,
@@ -42,18 +43,6 @@ class FuzzySearcher {
 
         return results.map { getMatchResult(it) }
     }
-}
-
-private val globalSearcher = FuzzySearcher()
-
-/** Searches on a list of strings based on an approximate pattern. */
-fun fuzzySearch(
-    sources: Collection<String>,
-    pattern: String,
-    maxResults: Int,
-    cancellationCheck: () -> Unit
-): List<MatchResult> {
-    return globalSearcher.search(sources, pattern, maxResults, cancellationCheck)
 }
 
 /**

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
@@ -20,6 +20,7 @@ import com.google.idea.perf.TracerController
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager.getApplication
 import com.intellij.openapi.rd.attachChild
+import com.intellij.openapi.ui.MessageType
 
 class VfsTracerController(
     private val view: VfsTracerView,
@@ -55,7 +56,14 @@ class VfsTracerController(
 
     private fun handleCommand(command: String) {
         when (command) {
-            "start" -> VirtualFileTracer.startVfsTracing()
+            "start" -> {
+                val errors = VirtualFileTracer.startVfsTracing()
+                if (errors.isNotEmpty()) {
+                    val errorString = errors.joinToString("\n\n")
+                    LOG.error(errorString)
+                    view.showCommandBalloon(errorString, MessageType.ERROR)
+                }
+            }
             "stop" -> VirtualFileTracer.stopVfsTracing()
             "clear" -> {
                 accumulatedStats.clear()

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerView.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerView.kt
@@ -79,7 +79,7 @@ class VfsTracerDialog: DialogWrapper(null, null, false, IdeModalityType.IDE, fal
 }
 
 class VfsTracerView(parentDisposable: Disposable): TracerView() {
-    val controller = VfsTracerController(this, parentDisposable)
+    override val controller = VfsTracerController(this, parentDisposable)
     override val commandLine: TextFieldWithCompletion
     override val progressBar: JProgressBar
     override val refreshTimeLabel: JBLabel

--- a/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTracer.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VirtualFileTracer.kt
@@ -16,7 +16,7 @@
 
 package com.google.idea.perf.vfstracer
 
-import com.google.idea.perf.methodtracer.AgentLoader
+import com.google.idea.perf.AgentLoader
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.psi.PsiElement
 import com.intellij.util.Processor

--- a/src/test/java/com/google/idea/perf/AgentLoaderTest.kt
+++ b/src/test/java/com/google/idea/perf/AgentLoaderTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.idea.perf.methodtracer
+package com.google.idea.perf
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Test

--- a/src/test/java/com/google/idea/perf/methodtracer/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/CallTreeTest.kt
@@ -16,7 +16,6 @@
 
 package com.google.idea.perf.methodtracer
 
-import com.google.idea.perf.agent.Argument
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/src/test/java/com/google/idea/perf/methodtracer/CallTreeTest.kt
+++ b/src/test/java/com/google/idea/perf/methodtracer/CallTreeTest.kt
@@ -22,26 +22,14 @@ import org.junit.Test
 class CallTreeTest {
 
     private class Tree(
-        override val tracepoint: Tracepoint,
-        callCount: Long,
-        wallTime: Long,
-        maxWallTime: Long,
-        override val argSetStats: Map<ArgSet, Stats> = emptyMap(),
-        childrenList: List<Tree> = emptyList()
-    ): CallTree {
-
-        override val stats = Stats(callCount, wallTime, maxWallTime)
-        override val children = childrenList.associateBy { it.tracepoint }
-    }
-
-    data class Stats(
+        override val methodCall: MethodCall,
         override val callCount: Long,
         override val wallTime: Long,
-        override val maxWallTime: Long
-    ): CallTree.Stats
-
-    private fun newArgSet(vararg values: Any?): ArgSet =
-        ArgSet(values.mapIndexed { i, value -> Argument(value, i.toByte()) }.toTypedArray())
+        override val maxWallTime: Long,
+        childrenList: List<Tree> = emptyList()
+    ): CallTree {
+        override val children = childrenList.associateBy { it.methodCall }
+    }
 
     class TestClock: CallTreeBuilder.Clock {
         var time = 0L
@@ -55,74 +43,51 @@ class CallTreeTest {
 
     @Test
     fun testFlatTracepointStats() {
-        val simple1 = Tracepoint("simple1")
-        val simple2 = Tracepoint("simple2")
-        val simple3 = Tracepoint("simple3")
+        val simple1 = MethodCall(Tracepoint("simple1"), null)
+        val simple2 = MethodCall(Tracepoint("simple2"), null)
+        val simple3 = MethodCall(Tracepoint("simple3"), null)
 
-        val selfRecursion = Tracepoint("selfRecursion")
+        val withArgumentTracepoint = Tracepoint("withArgument")
+        val withArgument1 = MethodCall(withArgumentTracepoint, "100")
+        val withArgument2 = MethodCall(withArgumentTracepoint, "200")
 
-        val mutualRecursion1 = Tracepoint("mutualRecursion1")
-        val mutualRecursion2 = Tracepoint("mutualRecursion2")
+        val selfRecursion = MethodCall(Tracepoint("selfRecursion"), null)
 
-        val tree = Tree(Tracepoint.ROOT, 0, 0, 0, emptyMap(), listOf(
+        val mutualRecursion1 = MethodCall(Tracepoint("mutualRecursion1"), null)
+        val mutualRecursion2 = MethodCall(Tracepoint("mutualRecursion2"), null)
+
+        val tree = Tree(MethodCall.ROOT, 0, 0, 0, listOf(
             // Simple.
-            Tree(simple1, 16, 1600, 100,
-                mapOf(newArgSet(null) to Stats(8, 800, 100)),
-                listOf(
-                    Tree(simple2, 8, 800, 100,
-                        mapOf(
-                            newArgSet("arg0", "foo") to Stats(4, 600, 20),
-                            newArgSet("arg0", "bar") to Stats(8, 400, 40)
-                        ),
-                        listOf(
-                            Tree(simple3, 2, 200, 150)
-                        )
-                    ),
-                    Tree(simple3, 4, 400, 100, emptyMap(),
-                        listOf(
-                            Tree(simple2, 1, 100, 100,
-                                mapOf(newArgSet("arg0", "foo") to Stats(4, 600, 40))
-                            )
-                        )
-                    )
-                )
-            ),
+            Tree(simple1, 16, 1600, 100, listOf(
+                Tree(simple2, 8, 800, 100, listOf(
+                    Tree(simple3, 2, 200, 150)
+                )),
+                Tree(simple3, 4, 400, 100, listOf(
+                    Tree(simple2, 1, 100, 100)
+                ))
+            )),
+
+            // With arguments.
+            Tree(withArgument1, 10, 600, 100, listOf(
+                Tree(withArgument2, 5, 400, 100)
+            )),
+            Tree(withArgument2, 10, 800, 100),
 
             // Self recursion.
-            Tree(selfRecursion, 4, 400, 200,
-                mapOf(
-                    newArgSet("arg0", "foo") to Stats(4, 600, 20),
-                    newArgSet("arg0", "bar") to Stats(8, 400, 40)
-                ),
-                listOf(
-                    Tree(selfRecursion, 2, 200, 100,
-                        mapOf(newArgSet("arg0", "bar") to Stats(8, 200, 20)),
-                        listOf(
-                            Tree(selfRecursion, 1, 100, 100)
-                        )
-                    )
-                )
-            ),
+            Tree(selfRecursion, 4, 400, 200, listOf(
+                Tree(selfRecursion, 2, 200, 100, listOf(
+                    Tree(selfRecursion, 1, 100, 100)
+                ))
+            )),
 
             // Mutual recursion.
-            Tree(mutualRecursion1, 1, 800, 800,
-                mapOf(
-                    newArgSet("arg0", "foo") to Stats(4, 600, 20),
-                    newArgSet("arg0", "bar") to Stats(8, 400, 40)
-                ),
-                listOf(
-                    Tree(mutualRecursion2, 2, 400, 200, emptyMap(),
-                        listOf(
-                            Tree(mutualRecursion1, 4, 200, 50,
-                                mapOf(newArgSet("arg0", "bar") to Stats(8, 200, 20)),
-                                listOf(
-                                    Tree(mutualRecursion2, 8, 100, 13)
-                                )
-                            )
-                        )
-                    )
-                )
-            )
+            Tree(mutualRecursion1, 1, 800, 800, listOf(
+                Tree(mutualRecursion2, 2, 400, 200, listOf(
+                    Tree(mutualRecursion1, 4, 200, 50, listOf(
+                        Tree(mutualRecursion2, 8, 100, 13)
+                    ))
+                ))
+            ))
         ))
 
         val allStats = TreeAlgorithms.computeFlatTracepointStats(tree)
@@ -141,30 +106,33 @@ class CallTreeTest {
             simple1: 16 calls, 1600 ns, 100 ns
             simple2: 9 calls, 900 ns, 100 ns
             simple3: 6 calls, 600 ns, 150 ns
+            withArgument: 25 calls, 1400 ns, 100 ns
         """.trimIndent()
 
         assertEquals(expected, allStats)
 
-        val argSetStats = ArgStatMap.fromCallTree(tree).tracepoints.toList()
+        val argStats = ArgStatMap.fromCallTree(tree).tracepoints.toList()
             .flatMap { pair -> pair.second.map { pair.first to it } }
             .sortedBy { it.first.displayName }
             .joinToString(separator = "\n") { (tracepoint, stats) ->
-                with (stats) {
-                    "$tracepoint($args): $callCount calls, $wallTime ns, $maxWallTime ns"
+                with(stats) {
+                    "$tracepoint(${args ?: ""}): $callCount calls, $wallTime ns, $maxWallTime ns"
                 }
             }
 
         val expectedArgStats = """
-            mutualRecursion1(arg0, foo): 4 calls, 600 ns, 20 ns
-            mutualRecursion1(arg0, bar): 16 calls, 400 ns, 40 ns
-            selfRecursion(arg0, foo): 4 calls, 600 ns, 20 ns
-            selfRecursion(arg0, bar): 16 calls, 400 ns, 40 ns
-            simple1(null): 8 calls, 800 ns, 100 ns
-            simple2(arg0, foo): 8 calls, 1200 ns, 40 ns
-            simple2(arg0, bar): 8 calls, 400 ns, 40 ns
+            [root](): 0 calls, 0 ns, 0 ns
+            mutualRecursion1(): 5 calls, 800 ns, 800 ns
+            mutualRecursion2(): 10 calls, 400 ns, 200 ns
+            selfRecursion(): 7 calls, 400 ns, 200 ns
+            simple1(): 16 calls, 1600 ns, 100 ns
+            simple2(): 9 calls, 900 ns, 100 ns
+            simple3(): 6 calls, 600 ns, 150 ns
+            withArgument(100): 10 calls, 600 ns, 100 ns
+            withArgument(200): 15 calls, 1200 ns, 100 ns
         """.trimIndent()
 
-        assertEquals(expectedArgStats, argSetStats)
+        assertEquals(expectedArgStats, argStats)
     }
 
     @Test
@@ -172,55 +140,54 @@ class CallTreeTest {
         val clock = TestClock()
         val builder = CallTreeBuilder(clock)
 
-        val simple1 = Tracepoint("simple1")
-        val simple2 = Tracepoint("simple2")
-        val simple3 = Tracepoint("simple3")
+        val simple1 = MethodCall(Tracepoint("simple1"), null)
+        val simple2 = MethodCall(Tracepoint("simple2"), null)
+        val simple3 = MethodCall(Tracepoint("simple3"), null)
 
-        val selfRecursion = Tracepoint("selfRecursion")
+        val selfRecursion = MethodCall(Tracepoint("selfRecursion"), null)
 
-        val mutualRecursion1 = Tracepoint("mutualRecursion1")
-        val mutualRecursion2 = Tracepoint("mutualRecursion2")
+        val mutualRecursion1 = MethodCall(Tracepoint("mutualRecursion1"), null)
+        val mutualRecursion2 = MethodCall(Tracepoint("mutualRecursion2"), null)
 
         // Simple.
         builder.push(simple1)
         builder.push(simple2)
         builder.push(simple3); clock.time++
-        builder.pop(simple3)
-        builder.pop(simple2); clock.time++
-        builder.pop(simple1)
+        builder.pop(simple3.tracepoint)
+        builder.pop(simple2.tracepoint); clock.time++
+        builder.pop(simple1.tracepoint)
 
         // Simple (longer).
         builder.push(simple1)
         builder.push(simple2); clock.time++
         builder.push(simple3); clock.time++
-        builder.pop(simple3); clock.time++
-        builder.pop(simple2)
+        builder.pop(simple3.tracepoint); clock.time++
+        builder.pop(simple2.tracepoint)
         builder.push(simple2); clock.time++
-        builder.pop(simple2)
-        builder.pop(simple1)
+        builder.pop(simple2.tracepoint)
+        builder.pop(simple1.tracepoint)
 
         // Self recursion.
         builder.push(selfRecursion); clock.time++
         builder.push(selfRecursion); clock.time++
         builder.push(selfRecursion); clock.time++
-        builder.pop(selfRecursion); clock.time++
-        builder.pop(selfRecursion); clock.time++
-        builder.pop(selfRecursion)
+        builder.pop(selfRecursion.tracepoint); clock.time++
+        builder.pop(selfRecursion.tracepoint); clock.time++
+        builder.pop(selfRecursion.tracepoint)
 
         // Mutual recursion.
         builder.push(mutualRecursion1); clock.time++
         builder.push(mutualRecursion2); clock.time++
         builder.push(mutualRecursion1); clock.time++
         builder.push(mutualRecursion2); clock.time++
-        builder.pop(mutualRecursion2)
-        builder.pop(mutualRecursion1)
-        builder.pop(mutualRecursion2)
-        builder.pop(mutualRecursion1)
+        builder.pop(mutualRecursion2.tracepoint)
+        builder.pop(mutualRecursion1.tracepoint)
+        builder.pop(mutualRecursion2.tracepoint)
+        builder.pop(mutualRecursion1.tracepoint)
 
         fun StringBuilder.printTree(node: CallTree, indent: String) {
-            val tracepoint = node.tracepoint
-            with(node.stats) {
-                appendln("$indent$tracepoint: $callCount calls, $wallTime ns, $maxWallTime ns")
+            with(node) {
+                appendln("$indent$methodCall: $callCount calls, $wallTime ns, $maxWallTime ns")
             }
             for (child in node.children.values) {
                 printTree(child, "$indent  ")
@@ -235,17 +202,17 @@ class CallTreeTest {
 
         buildAndCheckTree(
             """
-            [root]: 0 calls, 15 ns, 15 ns
-              simple1: 2 calls, 6 ns, 4 ns
-                simple2: 3 calls, 5 ns, 3 ns
-                  simple3: 2 calls, 2 ns, 1 ns
-              selfRecursion: 1 calls, 5 ns, 5 ns
-                selfRecursion: 1 calls, 3 ns, 3 ns
-                  selfRecursion: 1 calls, 1 ns, 1 ns
-              mutualRecursion1: 1 calls, 4 ns, 4 ns
-                mutualRecursion2: 1 calls, 3 ns, 3 ns
-                  mutualRecursion1: 1 calls, 2 ns, 2 ns
-                    mutualRecursion2: 1 calls, 1 ns, 1 ns
+            [root](): 0 calls, 15 ns, 15 ns
+              simple1(): 2 calls, 6 ns, 4 ns
+                simple2(): 3 calls, 5 ns, 3 ns
+                  simple3(): 2 calls, 2 ns, 1 ns
+              selfRecursion(): 1 calls, 5 ns, 5 ns
+                selfRecursion(): 1 calls, 3 ns, 3 ns
+                  selfRecursion(): 1 calls, 1 ns, 1 ns
+              mutualRecursion1(): 1 calls, 4 ns, 4 ns
+                mutualRecursion2(): 1 calls, 3 ns, 3 ns
+                  mutualRecursion1(): 1 calls, 2 ns, 2 ns
+                    mutualRecursion2(): 1 calls, 1 ns, 1 ns
             """.trimIndent()
         )
 
@@ -254,32 +221,32 @@ class CallTreeTest {
         builder.push(simple3); clock.time++
         buildAndCheckTree(
             """
-            [root]: 0 calls, 3 ns, 18 ns
-              simple1: 1 calls, 3 ns, 3 ns
-                simple2: 1 calls, 2 ns, 2 ns
-                  simple3: 1 calls, 1 ns, 1 ns
+            [root](): 0 calls, 3 ns, 18 ns
+              simple1(): 1 calls, 3 ns, 3 ns
+                simple2(): 1 calls, 2 ns, 2 ns
+                  simple3(): 1 calls, 1 ns, 1 ns
             """.trimIndent()
         )
 
         clock.time += 10
         buildAndCheckTree(
             """
-            [root]: 0 calls, 10 ns, 28 ns
-              simple1: 0 calls, 10 ns, 13 ns
-                simple2: 0 calls, 10 ns, 12 ns
-                  simple3: 0 calls, 10 ns, 11 ns
+            [root](): 0 calls, 10 ns, 28 ns
+              simple1(): 0 calls, 10 ns, 13 ns
+                simple2(): 0 calls, 10 ns, 12 ns
+                  simple3(): 0 calls, 10 ns, 11 ns
             """.trimIndent()
         )
 
-        builder.pop(simple3); clock.time++
-        builder.pop(simple2); clock.time++
-        builder.pop(simple1)
+        builder.pop(simple3.tracepoint); clock.time++
+        builder.pop(simple2.tracepoint); clock.time++
+        builder.pop(simple1.tracepoint)
         buildAndCheckTree(
             """
-            [root]: 0 calls, 2 ns, 30 ns
-              simple1: 0 calls, 2 ns, 15 ns
-                simple2: 0 calls, 1 ns, 13 ns
-                  simple3: 0 calls, 0 ns, 11 ns
+            [root](): 0 calls, 2 ns, 30 ns
+              simple1(): 0 calls, 2 ns, 15 ns
+                simple2(): 0 calls, 1 ns, 13 ns
+                  simple3(): 0 calls, 0 ns, 11 ns
             """.trimIndent()
         )
     }
@@ -289,11 +256,11 @@ class CallTreeTest {
         val clock = TestClock()
         val builder = CallTreeBuilder(clock)
         val simple = Tracepoint("simple1", null, TracepointFlags.TRACE_ALL)
+        val simpleInstance = MethodCall(simple, null)
 
         fun StringBuilder.printTree(node: CallTree, indent: String) {
-            val tracepoint = node.tracepoint
-            with(node.stats) {
-                appendln("$indent$tracepoint: $callCount calls, $wallTime ns, $maxWallTime ns")
+            with(node) {
+                appendln("$indent$methodCall: $callCount calls, $wallTime ns, $maxWallTime ns")
             }
             for (child in node.children.values) {
                 printTree(child, "$indent  ")
@@ -307,47 +274,47 @@ class CallTreeTest {
         }
 
         // Given an enabled tracepoint, disable tracepoint midway.
-        builder.push(simple)
+        builder.push(simpleInstance)
         clock.time++
         simple.unsetFlags(TracepointFlags.TRACE_ALL)
         builder.pop(simple)
 
         buildAndCheckTree(
             """
-            [root]: 0 calls, 1 ns, 1 ns
-              simple1: 1 calls, 1 ns, 1 ns
+            [root](): 0 calls, 1 ns, 1 ns
+              simple1(): 1 calls, 1 ns, 1 ns
             """.trimIndent()
         )
 
         // Given a disabled tracepoint, enable tracepoint midway.
-        builder.push(simple)
+        builder.push(simpleInstance)
         clock.time++
         simple.setFlags(TracepointFlags.TRACE_ALL)
         builder.pop(simple)
 
         buildAndCheckTree(
             """
-            [root]: 0 calls, 1 ns, 2 ns
-              simple1: 0 calls, 0 ns, 0 ns
+            [root](): 0 calls, 1 ns, 2 ns
+              simple1(): 0 calls, 0 ns, 0 ns
             """.trimIndent()
         )
 
         // Given an enabled tracepoint, disable tracepoint and build tree midway.
-        builder.push(simple)
+        builder.push(simpleInstance)
         clock.time++
         simple.unsetFlags(TracepointFlags.TRACE_ALL)
         buildAndCheckTree(
             """
-            [root]: 0 calls, 1 ns, 3 ns
-              simple1: 1 calls, 1 ns, 1 ns
+            [root](): 0 calls, 1 ns, 3 ns
+              simple1(): 1 calls, 1 ns, 1 ns
             """.trimIndent()
         )
 
         clock.time += 10
         buildAndCheckTree(
             """
-            [root]: 0 calls, 10 ns, 13 ns
-              simple1: 0 calls, 10 ns, 11 ns
+            [root](): 0 calls, 10 ns, 13 ns
+              simple1(): 0 calls, 10 ns, 11 ns
             """.trimIndent()
         )
 
@@ -355,92 +322,86 @@ class CallTreeTest {
         builder.pop(simple)
         buildAndCheckTree(
             """
-            [root]: 0 calls, 1 ns, 14 ns
-              simple1: 0 calls, 1 ns, 12 ns
+            [root](): 0 calls, 1 ns, 14 ns
+              simple1(): 0 calls, 1 ns, 12 ns
             """.trimIndent()
         )
     }
 
     @Test
     fun testCallTreeBuilderWithArgs() {
-        fun CallTreeBuilder.push(tracepoint: Tracepoint, vararg args: Any?) {
-            push(
-                tracepoint,
-                args.mapIndexed { i, value -> Argument(value, i.toByte()) }.toTypedArray()
-            )
-        }
-
         val clock = TestClock()
         val builder = CallTreeBuilder(clock)
 
-        val simple1 = Tracepoint("simple1")
-        val simple2 = Tracepoint("simple2")
-        val simple3 = Tracepoint("simple3")
+        val simpleTracepoint = Tracepoint("simple")
+        val simple1 = MethodCall(simpleTracepoint, "arg1")
+        val simple2 = MethodCall(simpleTracepoint, "arg2")
+        val simple3 = MethodCall(simpleTracepoint, "arg3")
 
-        val selfRecursion = Tracepoint("selfRecursion")
+        val selfRecursion = MethodCall(Tracepoint("selfRecursion"), "myArg")
 
-        val mutualRecursion1 = Tracepoint("mutualRecursion1")
-        val mutualRecursion2 = Tracepoint("mutualRecursion2")
+        val mutualRecursion1 = MethodCall(Tracepoint("mutualRecursion1"), "myArg")
+        val mutualRecursion2 = MethodCall(Tracepoint("mutualRecursion2"), "myArg")
 
         // Simple.
         builder.push(simple1)
-        builder.push(simple2, "arg0", "foo"); clock.time++
+        builder.push(simple2); clock.time++
         builder.push(simple3); clock.time++
-        builder.pop(simple3); clock.time++
-        builder.pop(simple2)
-        builder.push(simple2, "arg0", "foo"); clock.time++
-        builder.pop(simple2)
-        builder.push(simple2, "arg0", "bar"); clock.time++
-        builder.pop(simple2)
-        builder.pop(simple1)
+        builder.pop(simple3.tracepoint); clock.time++
+        builder.pop(simple2.tracepoint)
+        builder.push(simple2); clock.time++
+        builder.pop(simple2.tracepoint)
+        builder.push(simple2); clock.time++
+        builder.pop(simple2.tracepoint)
+        builder.pop(simple1.tracepoint)
 
         // Self recursion.
-        builder.push(selfRecursion, "myArg"); clock.time++
-        builder.push(selfRecursion, "myArg"); clock.time++
-        builder.push(selfRecursion, "myArg"); clock.time++
-        builder.pop(selfRecursion); clock.time++
-        builder.pop(selfRecursion); clock.time++
-        builder.pop(selfRecursion)
+        builder.push(selfRecursion); clock.time++
+        builder.push(selfRecursion); clock.time++
+        builder.push(selfRecursion); clock.time++
+        builder.pop(selfRecursion.tracepoint); clock.time++
+        builder.pop(selfRecursion.tracepoint); clock.time++
+        builder.pop(selfRecursion.tracepoint)
 
         // Mutual recursion.
-        builder.push(mutualRecursion1, "myArg"); clock.time++
+        builder.push(mutualRecursion1); clock.time++
         builder.push(mutualRecursion2); clock.time++
-        builder.push(mutualRecursion1, "myArg"); clock.time++
+        builder.push(mutualRecursion1); clock.time++
         builder.push(mutualRecursion2); clock.time++
-        builder.pop(mutualRecursion2)
-        builder.pop(mutualRecursion1)
-        builder.pop(mutualRecursion2)
-        builder.pop(mutualRecursion1)
+        builder.pop(mutualRecursion2.tracepoint)
+        builder.pop(mutualRecursion1.tracepoint)
+        builder.pop(mutualRecursion2.tracepoint)
+        builder.pop(mutualRecursion1.tracepoint)
 
-        fun CallTree.get(firstTracepoint: Tracepoint, vararg tracepoints: Tracepoint): CallTree {
-            var child = this.children[firstTracepoint] ?: error("$firstTracepoint does not exist.")
+        fun CallTree.get(head: MethodCall, vararg tail: MethodCall): CallTree {
+            var child = this.children[head] ?: error("$head does not exist.")
 
-            for (tracepoint in tracepoints) {
-                child = child.children[tracepoint] ?: error("$tracepoint does not exist.")
+            for (methodCall in tail) {
+                child = child.children[methodCall] ?: error("$methodCall does not exist.")
             }
 
             return child
         }
 
         fun assertStats(
-            callCount: Long, wallTime: Long, maxWallTime: Long, tree: CallTree, vararg args: Any?
+            callCount: Long, wallTime: Long, maxWallTime: Long, tree: CallTree
         ) {
-            val actualStats = tree.argSetStats[newArgSet(*args)]
-            assertEquals(callCount, actualStats?.callCount)
-            assertEquals(wallTime, actualStats?.wallTime)
-            assertEquals(maxWallTime, actualStats?.maxWallTime)
+            assertEquals(callCount, tree.callCount)
+            assertEquals(wallTime, tree.wallTime)
+            assertEquals(maxWallTime, tree.maxWallTime)
         }
 
         val tree = builder.buildAndReset()
 
-        assertStats(2L, 4L, 3L, tree.get(simple1, simple2), "arg0", "foo")
-        assertStats(1L, 1L, 1L, tree.get(simple1, simple2), "arg0", "bar")
+        assertStats(1L, 5L, 5L, tree.get(simple1))
+        assertStats(3L, 5L, 3L, tree.get(simple1, simple2))
+        assertStats(1L, 1L, 1L, tree.get(simple1, simple2, simple3))
 
-        assertStats(1L, 5L, 5L, tree.get(selfRecursion), "myArg")
-        assertStats(1L, 3L, 3L, tree.get(selfRecursion, selfRecursion), "myArg")
-        assertStats(1L, 1L, 1L, tree.get(selfRecursion, selfRecursion, selfRecursion), "myArg")
+        assertStats(1L, 5L, 5L, tree.get(selfRecursion))
+        assertStats(1L, 3L, 3L, tree.get(selfRecursion, selfRecursion))
+        assertStats(1L, 1L, 1L, tree.get(selfRecursion, selfRecursion, selfRecursion))
 
-        assertStats(1L, 4L, 4L, tree.get(mutualRecursion1), "myArg")
-        assertStats(1L, 2L, 2L, tree.get(mutualRecursion1, mutualRecursion2, mutualRecursion1), "myArg")
+        assertStats(1L, 4L, 4L, tree.get(mutualRecursion1))
+        assertStats(1L, 2L, 2L, tree.get(mutualRecursion1, mutualRecursion2, mutualRecursion1))
     }
 }

--- a/src/test/java/com/google/idea/perf/util/MatchingTest.kt
+++ b/src/test/java/com/google/idea/perf/util/MatchingTest.kt
@@ -32,12 +32,13 @@ private fun assertMatch(expectMatch: Boolean, source: String, pattern: String) {
 }
 
 private fun assertSearch(
+    searcher: FuzzySearcher,
     patterns: List<String>,
     expectedMatches: List<String>,
     items: List<String>
 ) {
     for (pattern in patterns) {
-        val matches = fuzzySearch(items, pattern, -1) {}.map { it.source }
+        val matches = searcher.search(items, pattern, -1) {}.map { it.source }
         assertTrue(matches.containsAll(expectedMatches))
     }
 }
@@ -109,8 +110,11 @@ class MatchingTest {
 
     @Test
     fun testFuzzySearch() {
+        val searcher = FuzzySearcher()
+
         // Package search
         assertSearch(
+            searcher,
             listOf(
                 "com.google.idea.perf.",
                 "com.google.idea.perf",
@@ -124,6 +128,7 @@ class MatchingTest {
         )
 
         assertSearch(
+            searcher,
             listOf("java.lang.", "java.lang", "java.", "java"),
             javaLangClasses,
             allSampleClasses
@@ -131,6 +136,7 @@ class MatchingTest {
 
         // Class search
         assertSearch(
+            searcher,
             listOf("Tracer"),
             listOf(
                 "com.google.idea.perf.methodtracer.TracerConfig",
@@ -141,6 +147,7 @@ class MatchingTest {
         )
 
         assertSearch(
+            searcher,
             listOf(
                 "java.lang.String",
                 "String",


### PR DESCRIPTION
# Description

This pull request includes various improvements, bug fixes, and refactorings.

# Additions

### Added command history

Pressing the up arrow recalls the previously ran command, while the down arrow key recalls the next.

# Changes

### Decoupled `AgentLoader` from method tracer

`AgentLoader` is now serving many different tracers, it makes sense to decouple this class from the method tracer. This keep the project organized into a small and tidy tree of package dependencies.

### Replaced global fuzzy searcher function with local instances

This was just a small tweak, and it was made to reduce the API surface area of `Matcher.kt`.

### Improved method tracer autocomplete

- Autocomplete for `untrace` will now only display classees that are currently or have previously been traced.
- Added wildcard (`*`) autocomplete suggestion.

### Replace CLI enter key hack with a proper solution

`TextFieldWithCompletion` instances now use one line mode and can respond to enter key events. This will be useful later on for command history, which requires listening to the up and down arrow keys.

# Bug Fixes

### Fix partial tracing not working on exact methods

- **Steps to reproduce:**
  1. Open up method tracer
  2. Run "trace count tracer"
- **Result:** Tracer will also trace wall time, even though only we only intended to trace call count.
- **Cause:** traceAndRetransform on exact methods will always call TracerConfig.trace will TracepointFlags.TRACE_ALL as the parameter.
- **Fix:** Added a flags parameter to traceAndRetransform

### Fix partial tracing corrupting wall time values

- **Steps to reproduce:**
  1. Open up method tracer
  2. Run "trace count tracer"
- **Result:** Tracer will corrupt the wall time value.
- **Cause:** CallTreeBuilder::buildAndReset accumulated wall time values regardless of tracepoint flag values.
- **Fix:** Checked tracepoint flags before accumulating wall time values.

### Fix parameter value tracing corner case

- **Description:** Given this call tree, the expected wall time for `f(2)` is 15 milliseconds:
```
f(1), 10 ms
    f(2), 5 ms
f(2), 10 ms
```
- **Fix:** Call trees now refer to an instance of `MethodCall`, where `MethodCall` consists of a tracepoint and a list of arguments. `ArgSet`s have been removed.
