### PR TITLE
Pass --no-daemon in CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Build and test
       uses: eskatos/gradle-command-action@c6b57b9 # v1.3.2
       with:
-        arguments: build
+        arguments: build --no-daemon
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
       env:


### PR DESCRIPTION
On Windows we get an error when trying to save the Gradle dependencies
cache: "Unable to delete dependencies lock files, try using
--no-daemon." This commit attempts to fix that.