### PR TITLE
Add a basic benchmark for tracing overhead

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,7 @@ tasks.runIde {
 
 tasks.test {
     testLogging.exceptionFormat = FULL
+    testLogging.showStandardStreams = isCI
     enableAgent(atStartup = true) // TODO: Ideally we would also test loading the agent on demand.
 }
 

--- a/src/main/java/com/google/idea/perf/methodtracer/CallTree.kt
+++ b/src/main/java/com/google/idea/perf/methodtracer/CallTree.kt
@@ -23,6 +23,15 @@ interface CallTree {
     val wallTime: Long
     val maxWallTime: Long
     val children: Map<MethodCall, CallTree>
+
+    fun allNodesInSubtree(): Sequence<CallTree> {
+        return sequence {
+            yield(this@CallTree)
+            for (child in children.values) {
+                yieldAll(child.allNodesInSubtree())
+            }
+        }
+    }
 }
 
 /** A mutable call tree implementation. */

--- a/src/main/java/com/google/idea/perf/util/Util.kt
+++ b/src/main/java/com/google/idea/perf/util/Util.kt
@@ -27,6 +27,8 @@ inline fun <T> Iterable<T>.sumByLong(selector: (T) -> Long): Long {
     return sum
 }
 
+inline fun <T> Sequence<T>.sumByLong(selector: (T) -> Long): Long = asIterable().sumByLong(selector)
+
 // Helper methods for locale-aware number rendering.
 private val formatter = NumberFormat.getInstance()
 fun formatNum(num: Long): String = formatter.format(num)


### PR DESCRIPTION
This benchmark is not very scientific, but it should give us some reasonable ballpark numbers.

Right now, tracing overhead seems to be around 130 ns per call on Mac.