### PR TITLE
Create a config tab to show user trace requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build/
 /.idea/uiDesigner.xml
 /.idea/*.iml
 /.idea/modules.xml
+
+.idea/libraries-with-intellij-classes.xml
+.idea/runConfigurations.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,9 @@
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,9 @@ tasks.runIde {
     jvmArgs("-Djdk.module.illegalAccess.silent=true")
     jvmArgs("-XX:+UseCompressedOops")
 
+    jvmArgs("-Xms512m")
+    jvmArgs("-Xmx2048m")
+
     enableAgent()
 }
 

--- a/src/main/java/com/google/idea/perf/cvtracer/CachedValueTracerController.kt
+++ b/src/main/java/com/google/idea/perf/cvtracer/CachedValueTracerController.kt
@@ -35,7 +35,7 @@ class CachedValueTracerController(
 ) : Disposable {
     companion object {
         private val LOG = Logger.getInstance(CachedValueTracerController::class.java)
-        private const val REFRESH_DELAY_MS = 30L
+        private const val REFRESH_DELAY_MS = 100L
     }
 
     // For simplicity we run all tasks on a single-thread executor.

--- a/src/main/java/com/google/idea/perf/tracer/TracerCommand.kt
+++ b/src/main/java/com/google/idea/perf/tracer/TracerCommand.kt
@@ -18,6 +18,7 @@ package com.google.idea.perf.tracer
 
 import com.google.idea.perf.tracer.TraceOption.COUNT_AND_WALL_TIME
 import com.google.idea.perf.tracer.TraceOption.COUNT_ONLY
+import com.google.idea.perf.tracer.TraceOption.UNTRACE
 
 /** A tracer CLI command */
 sealed class TracerCommand {
@@ -56,7 +57,8 @@ sealed class TracerCommand {
 /** Represents what to trace */
 enum class TraceOption {
     COUNT_AND_WALL_TIME,
-    COUNT_ONLY;
+    COUNT_ONLY,
+    UNTRACE;
 }
 
 /** A set of methods that the tracer will trace. */
@@ -68,7 +70,9 @@ sealed class TraceTarget {
     data class Method(
         val className: String,
         val methodName: String?,
-        val parameterIndexes: List<Int>? = emptyList()
+        val parameterIndexes: List<Int>? = emptyList(),
+        // a redundant option to support user config tab
+        val traceOption: TraceOption = COUNT_AND_WALL_TIME
     ): TraceTarget()
 
     val errors: List<String>

--- a/src/main/java/com/google/idea/perf/tracer/TracerController.kt
+++ b/src/main/java/com/google/idea/perf/tracer/TracerController.kt
@@ -129,6 +129,7 @@ class TracerController(
                     }
                     is TraceTarget.Method -> {
                         runWithProgress { progress ->
+                            TracerUserConfig.addUserTraceRequest(command.target)
                             val clazz = command.target.className
                             val method = command.target.methodName ?: "*"
                             val methodPattern = MethodFqName(clazz, method, "*")

--- a/src/main/java/com/google/idea/perf/tracer/TracerUserConfig.kt
+++ b/src/main/java/com/google/idea/perf/tracer/TracerUserConfig.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.tracer
+
+import com.google.idea.perf.agent.TracerHook
+import com.google.idea.perf.tracer.TracerConfig.getMethodTraceData
+import com.google.idea.perf.tracer.TracerConfig.getMethodTracepoint
+import com.google.idea.perf.tracer.TracerConfig.shouldInstrumentClass
+import java.util.TreeMap
+
+// TODO(baskakov): update description
+/**
+ * [TracerUserConfig] essentially keeps track of which methods should be traced.
+ * See also [TracerConfigUtil].
+ *
+ * When the user adds a new trace request, it ends up here. [TracerClassFileTransformer]
+ * finds out about the request by calling [shouldInstrumentClass] and [getMethodTraceData].
+ *
+ * [TracerUserConfig] also keeps track of an integer method ID for each traced method.
+ * The method ID is injected into the method bytecode and passed to the [TracerHook],
+ * which then uses [getMethodTracepoint] to retrieve the corresponding tracepoint.
+ * It is important for [getMethodTracepoint] to be fast and lock free.
+ *
+ * Note: there may be multiple tracing requests which apply to a given method.
+ * For simplicity, only the most recent applicable trace request is honored.
+ */
+object TracerUserConfig {
+
+    private val userTraceRequests = TreeMap<String, TraceTarget.Method>()
+
+    fun cloneUserTraceRequests(): List<TraceTarget.Method> {
+        return userTraceRequests.values.toList()
+    }
+
+    fun addUserTraceRequest(entry: TraceTarget.Method) {
+        val sortKey = concatClassAndMethod(entry)
+        userTraceRequests[sortKey] = entry
+    }
+
+    fun addUserUntraceRequest(entry: TraceTarget.Method) {
+        val sortKey = concatClassAndMethod(entry)
+        userTraceRequests.remove(sortKey)
+    }
+
+    private fun concatClassAndMethod(entry: TraceTarget.Method): String {
+        return "${entry.className}#${entry.methodName ?: ""}"
+    }
+
+}

--- a/src/main/java/com/google/idea/perf/tracer/ui/TracerConfigModel.kt
+++ b/src/main/java/com/google/idea/perf/tracer/ui/TracerConfigModel.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.tracer.ui
+
+import com.google.idea.perf.tracer.TraceOption
+import com.google.idea.perf.tracer.TraceTarget
+import javax.swing.table.AbstractTableModel
+import kotlin.math.min
+
+/** The table model for [TracerTable]. */
+class TracerConfigModel : AbstractTableModel() {
+    var data: List<TraceTarget.Method> = emptyList()
+
+    /** Table columns. */
+    enum class Column(val displayName: String, val type: Class<*>) {
+        OPTION("is traced", String::class.java),
+        CLASSES("class", String::class.java),
+        METHODS("method", String::class.java);
+
+        companion object {
+            val values = values()
+            val count = values.size
+            fun valueOf(col: Int): Column = values[col]
+        }
+    }
+
+    override fun getColumnCount(): Int = Column.count
+
+    override fun getColumnName(col: Int): String = Column.valueOf(col).displayName
+
+    override fun getColumnClass(col: Int): Class<*> = Column.valueOf(col).type
+
+    override fun getRowCount(): Int = data.size
+
+    override fun getValueAt(row: Int, col: Int): Any {
+        val stats = data[row]
+        return when (Column.valueOf(col)) {
+            Column.OPTION -> when(stats.traceOption) {
+                TraceOption.COUNT_AND_WALL_TIME -> "+"
+                TraceOption.COUNT_ONLY -> "%"
+                TraceOption.UNTRACE -> "-"
+            }
+            Column.CLASSES -> stats.className
+            Column.METHODS -> stats.methodName ?: ""
+        }
+    }
+
+    override fun isCellEditable(row: Int, column: Int): Boolean = false
+
+    fun setTracepointStats(newStats: List<TraceTarget.Method>) {
+        val oldStats = data
+        if (oldStats.size != newStats.size) {
+            data = newStats
+            fireTableDataChanged()
+            return
+        }
+
+//        // Generate table model events.
+//        val oldRows = oldStats.size
+//        val newRows = newStats.size
+//        when {
+//            newRows > oldRows -> fireTableRowsInserted(oldRows, newRows - 1)
+//            newRows < oldRows -> fireTableRowsDeleted(newRows, oldRows - 1)
+//        }
+//        val modifiedRows = min(oldRows, newRows)
+//        if (modifiedRows > 0) {
+//            fireTableRowsUpdated(0, modifiedRows - 1)
+//        }
+    }
+}

--- a/src/main/java/com/google/idea/perf/tracer/ui/TracerPanel.kt
+++ b/src/main/java/com/google/idea/perf/tracer/ui/TracerPanel.kt
@@ -83,7 +83,7 @@ class TracerPanel(
     private var uiOverhead = 0L
 
     companion object {
-        private const val REFRESH_DELAY_MS = 30L
+        private const val REFRESH_DELAY_MS = 100L
     }
 
     init {

--- a/src/main/java/com/google/idea/perf/tracer/ui/TracerPanel.kt
+++ b/src/main/java/com/google/idea/perf/tracer/ui/TracerPanel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.google.idea.perf.tracer.ui
 import com.google.idea.perf.tracer.CallTreeManager
 import com.google.idea.perf.tracer.CallTreeUtil
 import com.google.idea.perf.tracer.TracerController
+import com.google.idea.perf.tracer.TracerUserConfig
 import com.google.idea.perf.util.formatNsInMs
 import com.intellij.CommonBundle
 import com.intellij.ide.BrowserUtil
@@ -56,12 +57,7 @@ import javax.swing.JProgressBar
 import javax.swing.JSeparator
 import javax.swing.SwingConstants.HORIZONTAL
 
-// Things to improve:
-// * Optimization: only update the tracer tab that is currently visible.
-// * Optimization: fast path in updateCallTree() if the tree did not change.
-// * Reset UI overhead to 0 after 'clear' command.
-// * Focus traversal.
-
+// TODO(baskakov): updated description
 /**
  * This is the main tracer panel containing the command line, call tree view,
  * overhead labels, etc. It also polls for new call tree data in [updateCallTree].
@@ -78,6 +74,7 @@ class TracerPanel(
     private var showingEdtOnly = false
     private val listView: TracerTable
     private val treeView: TracerTree
+    private val configView: TracerUIConfig
     private val tracingOverheadLabel: JBLabel
     private val uiOverheadLabel: JBLabel
     private var uiOverhead = 0L
@@ -157,6 +154,13 @@ class TracerPanel(
             .setText("Tree")
             .setSideComponent(createTabSideComponent())
         tabs.addTab(treeTab)
+
+        // Config view.
+        configView = TracerUIConfig(TracerConfigModel())
+        val configTab = TabInfo(JBScrollPane(configView))
+            .setText("Config")
+            .setSideComponent(createTabSideComponent())
+        tabs.addTab(configTab)
 
         // Tracing overhead label.
         val overheadFont = JBFont
@@ -239,6 +243,7 @@ class TracerPanel(
         val stats = CallTreeUtil.computeFlatTracepointStats(treeSnapshot)
         listView.setTracepointStats(stats)
         treeView.setCallTree(treeSnapshot)
+        configView.setTracingConfig(TracerUserConfig.cloneUserTraceRequests())
 
         // Estimate tracing overhead.
         val tracingOverhead = CallTreeUtil.estimateTracingOverhead(treeSnapshot)

--- a/src/main/java/com/google/idea/perf/tracer/ui/TracerUIConfig.kt
+++ b/src/main/java/com/google/idea/perf/tracer/ui/TracerUIConfig.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.perf.tracer.ui
+
+import com.google.idea.perf.tracer.TraceTarget
+import com.google.idea.perf.tracer.ui.TracerConfigModel.Column
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
+import javax.swing.ListSelectionModel
+import javax.swing.table.JTableHeader
+
+// TODO(baskakov): update description
+/** Displays a list of tracepoints alongside their call counts and timing measurements. */
+class TracerUIConfig(private val model: TracerConfigModel) : JBTable(model) {
+
+    init {
+        configureTracerTableOrTree(this)
+    }
+
+    override fun createDefaultTableHeader(): JTableHeader {
+        return object: JBTableHeader() {
+            init {
+                // Override the renderer that JBTableHeader sets.
+                // The default, center-aligned renderer looks better.
+                defaultRenderer = createDefaultRenderer()
+            }
+        }
+    }
+
+    fun setTracingConfig(newStats: List<TraceTarget.Method>) {
+        model.setTracepointStats(newStats)
+    }
+
+    companion object {
+
+        /** Configuration common to both [TracerUIConfig] and [TracerTree]. */
+        fun configureTracerTableOrTree(table: JBTable) {
+            table.font = EditorUtil.getEditorFont()
+            table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+            table.setShowGrid(false)
+
+            // Ensure the row heights for TracerTable and TracerTree match each other.
+            table.rowHeight = JBUI.scale(22)
+
+            // Column rendering.
+            val tableColumns = table.columnModel.columns.toList()
+            for (tableColumn in tableColumns) {
+                val col = Column.valueOf(tableColumn.modelIndex)
+
+                // Column widths.
+                tableColumn.minWidth = 100
+                tableColumn.preferredWidth = when (col) {
+                    Column.OPTION -> 3
+                    Column.CLASSES -> Integer.MAX_VALUE
+                    Column.METHODS -> 100
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
@@ -33,7 +33,7 @@ class VfsTracerController(
 ) : Disposable {
     companion object {
         private val LOG = Logger.getInstance(VfsTracerController::class.java)
-        private const val REFRESH_DELAY_MS = 30L
+        private const val REFRESH_DELAY_MS = 100L
     }
 
     // For simplicity we run all tasks on a single-thread executor.


### PR DESCRIPTION
  add global TracerUserConfig to store raw user requests
  changed TraceTarget.Method to duplicate traceOption state
  since this information isn't available in MethodFqMatcher
