### PR TITLE
increase runIde memory and poll intervals, remove star imports

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,9 @@
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,9 @@ tasks.runIde {
     jvmArgs("-Djdk.module.illegalAccess.silent=true")
     jvmArgs("-XX:+UseCompressedOops")
 
+    jvmArgs("-Xms512m")
+    jvmArgs("-Xmx2048m")
+
     enableAgent()
 }
 

--- a/src/main/java/com/google/idea/perf/cvtracer/CachedValueTracerController.kt
+++ b/src/main/java/com/google/idea/perf/cvtracer/CachedValueTracerController.kt
@@ -35,7 +35,7 @@ class CachedValueTracerController(
 ) : Disposable {
     companion object {
         private val LOG = Logger.getInstance(CachedValueTracerController::class.java)
-        private const val REFRESH_DELAY_MS = 30L
+        private const val REFRESH_DELAY_MS = 100L
     }
 
     // For simplicity we run all tasks on a single-thread executor.

--- a/src/main/java/com/google/idea/perf/tracer/ui/TracerPanel.kt
+++ b/src/main/java/com/google/idea/perf/tracer/ui/TracerPanel.kt
@@ -83,7 +83,7 @@ class TracerPanel(
     private var uiOverhead = 0L
 
     companion object {
-        private const val REFRESH_DELAY_MS = 30L
+        private const val REFRESH_DELAY_MS = 100L
     }
 
     init {

--- a/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
+++ b/src/main/java/com/google/idea/perf/vfstracer/VfsTracerController.kt
@@ -33,7 +33,7 @@ class VfsTracerController(
 ) : Disposable {
     companion object {
         private val LOG = Logger.getInstance(VfsTracerController::class.java)
-        private const val REFRESH_DELAY_MS = 30L
+        private const val REFRESH_DELAY_MS = 100L
     }
 
     // For simplicity we run all tasks on a single-thread executor.


### PR DESCRIPTION
Sometimes `runIde` target runs out of memory